### PR TITLE
AdsNotification Header has nTimeStamp & nNotification backwards

### DIFF
--- a/AdsLib/AdsDef.h
+++ b/AdsLib/AdsDef.h
@@ -284,8 +284,8 @@ typedef struct {
 } AdsNotificationAttrib, * PAdsNotificationAttrib;
 
 typedef struct {
-    uint64_t nTimeStamp;
     uint32_t hNotification;
+    uint64_t nTimeStamp;
     uint32_t cbSampleSize;
 #ifndef __cplusplus
     uint8_t data[];


### PR DESCRIPTION
This changes the ordering of nTimeStamp and nNofiication fields for
the AdsNotificationHeader.

See [Beckhoff/ADS #12](https://github.com/Beckhoff/ADS/issues/12)

This now conforms to both the [TwinCAT 2 documentation](http://infosys.beckhoff.de/english.php?content=../content/1033/tcadsdll2/html/tcadsdll_strucadsnotificationheader.htm&id=21585)
and the [TwinCAT 3 documentation](http://infosys.beckhoff.de/english.php?content=../content/1033/tc3_adsdll2/html/tcadsdll_strucadsnotificationheader.htm&id=16945)