### PR TITLE
Catching badAlloc-Exceptions to fail with the specified ADS error code.

### DIFF
--- a/AdsLib/AmsRouter.cpp
+++ b/AdsLib/AmsRouter.cpp
@@ -37,7 +37,12 @@ long AmsRouter::AddRoute(AmsNetId ams, const IpV4& ip)
     auto conn = connections.find(ip);
     if (conn == connections.end()) {
         const auto isFirst = connections.empty();
-        conn = connections.emplace(ip, std::unique_ptr<AmsConnection>(new AmsConnection { *this, ip })).first;
+        try{
+            conn = connections.emplace(ip, std::unique_ptr<AmsConnection>(new AmsConnection { *this, ip })).first;
+        } catch (std::bad_alloc badAllocException) {
+            return GLOBALERR_NO_MEMORY;
+        }
+
         if (isFirst) {
             localAddr = AmsNetId {conn->second->ownIp};
         }


### PR DESCRIPTION
Hi,

thanks for your feedback on the first pull request. 
Using the pre-commit hook worked just fine.

I checked about throwing the badAlloc-Exception. The standard requires the new handler to throw that exception if the allocation fails and all major compilers after VC6 follow that rule. So there was no need to check for NULL and throw the exception manually.

Feel free to accept or reject this pull request. I think the library's error handling should be consistent 
and therefore the functions should return the error code instead of throwing an exception.

Regards
Michael