### PR TITLE
As proposed in the issues section: Object-Oriented interface + Example

### DIFF
--- a/AdsLib/AdsClient/AdsClient.h
+++ b/AdsLib/AdsClient/AdsClient.h
@@ -1,0 +1,292 @@
+/**
+   Objectoriented-Interface for AdsLib.
+
+   Example usage:
+   try
+   {
+   AdsClient client;
+   auto readUIntResponse = client.Read<uint32_t>(...);
+   auto readUIntArrayResponse = client.Read<uint32_t, 10>(...);
+   client.Write<uint32_t>(...);
+   client.WriteArray<uint32_t, 10>(...);
+   }
+   catch (AdsException& ex){};
+ */
+
+#pragma once
+#if (__cplusplus > 199711L || _MSC_VER >= 1700) // Check for c++11 support
+#include <memory>
+#include <cstring>
+#include "..\AdsLib.h"
+#include "AdsException.h"
+#include "AdsReadResponse.h"
+#include "AdsReadArrayResponse.h"
+
+class AdsClient {
+public:
+    AdsClient()
+    {
+        m_Port = AdsPortOpenEx();
+        if (0 == m_Port) {
+            throw AdsException(ADSERR_CLIENT_PORTNOTOPEN);
+        }
+    }
+
+    ~AdsClient()
+    {
+        AdsPortCloseEx(m_Port);
+    }
+
+    // Routing
+    static void AddRoute(const AmsNetId amsNetId, const std::string& ip)
+    {
+        auto error = AdsAddRoute(amsNetId, ip.c_str());
+        if (error) {throw AdsException(error); }
+    }
+
+    static void DeleteRoute(const AmsNetId amsNetId)
+    {
+        AdsDelRoute(amsNetId);
+    }
+
+    const AmsAddr GetLocalAddress() const
+    {
+        AmsAddr address;
+        auto error = AdsGetLocalAddressEx(m_Port, &address);
+        if (error) {throw AdsException(error); }
+        return address;
+    }
+
+    // Timeout
+    const uint32_t GetTimeout() const
+    {
+        uint32_t timeout = 0;
+        uint32_t error = AdsSyncGetTimeoutEx(m_Port, &timeout);
+        if (error) {throw AdsException(error); }
+        return timeout;
+    }
+    void SetTimeout(const uint32_t timeout) const
+    {
+        uint32_t error = AdsSyncSetTimeoutEx(m_Port, timeout);
+        if (error) {throw AdsException(error); }
+    }
+
+    // Device info
+    const DeviceInfo ReadDeviceInfo(const AmsAddr& address) const
+    {
+        DeviceInfo deviceInfo;
+        auto error = AdsSyncReadDeviceInfoReqEx(m_Port, &address, deviceInfo.name, &deviceInfo.version);
+        if (error) {throw AdsException(error); }
+        return deviceInfo;
+    }
+
+    // Read variables by symbolic name
+    template<typename T>
+    const AdsReadResponse<T> Read(
+        const AmsAddr&     address,
+        const std::string& symbolName) const
+    {
+        auto handle = GetHandle(address, symbolName.c_str());
+        AdsReadResponse<T> response;
+        uint32_t bytesRead = 0;
+        auto error = AdsSyncReadReqEx2(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_VALBYHND,
+            handle,
+            sizeof(T),
+            response.GetPointer(),
+            &bytesRead);
+        ReleaseHandle(address, handle);
+        if (error) {throw AdsException(error); }
+        response.SetBytesRead(bytesRead);
+        return response;
+    }
+
+    // Read variables by index group and index offset
+    template<typename T>
+    const AdsReadResponse<T> Read(
+        const AmsAddr& address,
+        const uint32_t indexGroup,
+        const uint32_t indexOffset) const
+    {
+        AdsReadResponse<T> response;
+        uint32_t bytesRead = 0;
+
+        auto error = AdsSyncReadReqEx2(
+            m_Port,
+            &address,
+            indexGroup,
+            indexOffset,
+            sizeof(T),
+            response.GetPointer(),
+            &bytesRead);
+        if (error) {throw AdsException(error); }
+        response.SetBytesRead(bytesRead);
+        return response;
+    }
+
+    // Read arrays by symbolic name
+    template<typename T, uint32_t count = 1>
+    const AdsReadArrayResponse<T, count> ReadArray(
+        const AmsAddr&     address,
+        const std::string& symbolName) const
+    {
+        auto handle = GetHandle(address, symbolName.c_str());
+        AdsReadArrayResponse<T, count> response;
+        uint32_t bytesRead = 0;
+
+        auto error = AdsSyncReadReqEx2(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_VALBYHND,
+            handle,
+            sizeof(T) * count,
+            response.GetPointer(),
+            &bytesRead);
+        ReleaseHandle(address, handle);
+        if (error) {throw AdsException(error); }
+        response.SetBytesRead(bytesRead);
+        return response;
+    }
+
+    // Read arrays by index group and index offset
+    template<typename T, uint32_t count = 1>
+    const AdsReadArrayResponse<T, count> ReadArray(
+        const AmsAddr& address,
+        const uint32_t indexGroup,
+        const uint32_t indexOffset) const
+    {
+        AdsReadArrayResponse<T, count> response;
+        uint32_t bytesRead = 0;
+
+        auto error = AdsSyncReadReqEx2(
+            m_Port,
+            &address,
+            indexGroup,
+            indexOffset,
+            sizeof(T) * count,
+            response.GetPointer(),
+            &bytesRead);
+        if (error) {throw AdsException(error); }
+        response.SetBytesRead(bytesRead);
+        return response;
+    }
+
+    // Write variable by symbolic name
+    template<typename T, uint32_t count = 1> void Write(
+        const AmsAddr&     address,
+        const std::string& symbolName,
+        const T&           value)
+    {
+        auto handle = GetHandle(address, symbolName.c_str());
+        auto error = AdsSyncWriteReqEx(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_VALBYHND,
+            handle,
+            sizeof(T) * count,
+            &value);
+        ReleaseHandle(address, handle);
+        if (error) {throw AdsException(error); }
+    }
+
+    // Write variable by index group and index offset
+    template<typename T, uint32_t count = 1> void Write(
+        const AmsAddr& address,
+        const uint32_t indexGroup,
+        const uint32_t indexOffset,
+        const T&       value)
+    {
+        auto error = AdsSyncWriteReqEx(
+            m_Port,
+            &address,
+            indexGroup,
+            indexOffset,
+            sizeof(T) * count,
+            &value
+            );
+        if (error) {throw AdsException(error); }
+    }
+
+    // Write array by symbolic name
+    template<typename T, uint32_t count = 1> void WriteArray(
+        const AmsAddr&     address,
+        const std::string& symbolName,
+        const T*           pValue)
+    {
+        auto handle = GetHandle(address, symbolName.c_str());
+        auto error = AdsSyncWriteReqEx(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_VALBYHND,
+            handle,
+            sizeof(T) * count,
+            pValue);
+        ReleaseHandle(address, handle);
+        if (error) {throw AdsException(error); }
+    }
+
+    // Write array by index group and index offset
+    template<typename T, uint32_t count = 1> void WriteArray(
+        const AmsAddr& address,
+        const uint32_t indexGroup,
+        const uint32_t indexOffset,
+        const T*       pValue)
+    {
+        auto error = AdsSyncWriteReqEx(
+            m_Port,
+            &address,
+            indexGroup,
+            indexOffset,
+            sizeof(T) * count,
+            pValue
+            );
+        if (error) {throw AdsException(error); }
+    }
+
+private:
+    uint32_t m_Port;
+
+    // Get the handle for a given symbol name
+    const uint32_t GetHandle(
+        const AmsAddr&    address,
+        const char* const symbolName) const
+    {
+        uint32_t handle = 0;
+        uint32_t bytesRead = 0;
+        uint32_t error = AdsSyncReadWriteReqEx2(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_HNDBYNAME, 0,
+            sizeof(handle), &handle,
+            strlen(symbolName),
+            (void*)symbolName,
+            &bytesRead
+            );
+
+        if (error || (sizeof(handle) != bytesRead)) {
+            throw AdsException(error);
+        }
+        return handle;
+    }
+
+    // Release a given handle
+    void ReleaseHandle(
+        const AmsAddr& address,
+        const uint32_t handle) const
+    {
+        uint32_t error = AdsSyncWriteReqEx(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_RELEASEHND, 0,
+            sizeof(handle), &handle
+            );
+
+        if (error) {
+            throw AdsException(error);
+        }
+    }
+};
+
+#endif

--- a/AdsLib/AdsClient/AdsException.h
+++ b/AdsLib/AdsClient/AdsException.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <stdexcept>
+#include <string>
+
+class AdsException : public std::exception {
+public:
+    AdsException(const long adsErrorCode) :
+        m_AdsErrorCode(adsErrorCode),
+        m_Message("Ads operation failed with error code " + std::to_string(adsErrorCode) + ".")
+    {}
+
+    virtual ~AdsException() throw (){}
+
+    virtual const char* what() const throw ()
+    {
+        return m_Message.c_str();
+    }
+
+    const long getErrorCode() const
+    {
+        return m_AdsErrorCode;
+    }
+
+protected:
+    const long m_AdsErrorCode;
+    const std::string m_Message;
+};

--- a/AdsLib/AdsClient/AdsReadArrayResponse.h
+++ b/AdsLib/AdsClient/AdsReadArrayResponse.h
@@ -1,0 +1,64 @@
+/**
+    Class which is returned by the AdsClient ReadArray()-Operations.
+ */
+
+#pragma once
+
+#include <stdexcept>
+
+template<typename T, uint32_t count>
+class AdsReadArrayResponse {
+public:
+    AdsReadArrayResponse<T, count>()
+    {
+        m_pArray = std::shared_ptr<T>(new T[count], array_deleter<T>());
+        m_BytesRead = 0;
+    }
+
+    const T* Get() const
+    {
+        return m_pArray.get();
+    }
+
+    T* GetPointer() const
+    {
+        return m_pArray.get();
+    }
+
+    const uint32_t GetBytesRead() const
+    {
+        return m_BytesRead;
+    }
+
+    void SetBytesRead(const uint32_t bytesRead)
+    {
+        m_BytesRead = bytesRead;
+    }
+
+    const uint32_t GetElementsRead() const
+    {
+        return m_BytesRead / sizeof(T);
+    }
+
+    T operator[](uint32_t index)
+    {
+        if (index < m_BytesRead / sizeof(T)) {
+            return m_pArray.get()[index];
+        } else {
+            throw std::out_of_range("The requested index is not inside the range of elements read from the server");
+        }
+    }
+
+private:
+    std::shared_ptr<T> m_pArray;
+    uint32_t m_BytesRead;
+
+    template<typename T1>
+    class array_deleter {
+public:
+        void operator()(T1 const* p)
+        {
+            delete[] p;
+        }
+    };
+};

--- a/AdsLib/AdsClient/AdsReadResponse.h
+++ b/AdsLib/AdsClient/AdsReadResponse.h
@@ -1,0 +1,45 @@
+/**
+    Class which is returned by the AdsClient Read()-Operations.
+ */
+
+#pragma once
+
+#include <memory>
+
+template<typename T>
+class AdsReadResponse {
+public:
+    AdsReadResponse<T>()
+    {
+        m_pValue = std::shared_ptr<T>(new T);
+    }
+
+    const T& Get() const
+    {
+        return *m_pValue;
+    }
+
+    T* GetPointer() const
+    {
+        return m_pValue.get();
+    }
+
+    void SetBytesRead(const uint32_t bytesRead)
+    {
+        m_BytesRead = bytesRead;
+    }
+
+    const uint32_t GetBytesRead() const
+    {
+        return m_BytesRead;
+    }
+
+    operator T() const
+    {
+        return *m_pValue;
+    }
+
+private:
+    std::shared_ptr<T> m_pValue;
+    uint32_t m_BytesRead;
+};

--- a/AdsLib/AdsDef.h
+++ b/AdsLib/AdsDef.h
@@ -284,6 +284,22 @@ struct AdsVersion {
     uint16_t build;
 };
 
+/**
+ * @brief Maximum size for device name.
+ */
+static const size_t DEVICE_NAME_LENGTH = 16;
+
+/**
+ * @brief Device information containing device name and version.
+ */
+struct DeviceInfo {
+    /** Device name */
+    char name[DEVICE_NAME_LENGTH];
+
+    /** Device version as defined above */
+    AdsVersion version;
+};
+
 enum ADSTRANSMODE {
     ADSTRANS_NOTRANS = 0,
     ADSTRANS_CLIENTCYCLE = 1,

--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,14 @@ AdsLibTest.bin: AdsLibTest/main.o $(LIB_NAME)
 test: AdsLibTest.bin
 	./$<
 
-install: $(LIB_NAME) AdsLib.h AdsDef.h
-	cp $? $(INSTALL_DIR)/
+install: $(LIB_NAME) AdsLib.h AdsDef.h AdsClient
+	cp --recursive $? $(INSTALL_DIR)/
 
 clean:
 	rm -f *.a *.o *.bin AdsLibTest/*.o
 
 uncrustify:
-	uncrustify --no-backup -c tools/uncrustify.cfg AdsLib*/*.h AdsLib*/*.cpp example/*.cpp
+	uncrustify --no-backup -c tools/uncrustify.cfg AdsLib*/*.h AdsLib*/*.cpp example/*.cpp AdsLib*/AdsClient/*
 
 prepare-hooks:
 	rm -f .git/hooks/pre-commit

--- a/example/AdsClient/AdsClient.h
+++ b/example/AdsClient/AdsClient.h
@@ -1,0 +1,292 @@
+/**
+   Objectoriented-Interface for AdsLib.
+
+   Example usage:
+   try
+   {
+   AdsClient client;
+   auto readUIntResponse = client.Read<uint32_t>(...);
+   auto readUIntArrayResponse = client.Read<uint32_t, 10>(...);
+   client.Write<uint32_t>(...);
+   client.WriteArray<uint32_t, 10>(...);
+   }
+   catch (AdsException& ex){};
+ */
+
+#pragma once
+#if (__cplusplus > 199711L || _MSC_VER >= 1700) // Check for c++11 support
+#include <memory>
+#include <cstring>
+#include "..\AdsLib.h"
+#include "AdsException.h"
+#include "AdsReadResponse.h"
+#include "AdsReadArrayResponse.h"
+
+class AdsClient {
+public:
+    AdsClient()
+    {
+        m_Port = AdsPortOpenEx();
+        if (0 == m_Port) {
+            throw AdsException(ADSERR_CLIENT_PORTNOTOPEN);
+        }
+    }
+
+    ~AdsClient()
+    {
+        AdsPortCloseEx(m_Port);
+    }
+
+    // Routing
+    static void AddRoute(const AmsNetId amsNetId, const std::string& ip)
+    {
+        auto error = AdsAddRoute(amsNetId, ip.c_str());
+        if (error) {throw AdsException(error); }
+    }
+
+    static void DeleteRoute(const AmsNetId amsNetId)
+    {
+        AdsDelRoute(amsNetId);
+    }
+
+    const AmsAddr GetLocalAddress() const
+    {
+        AmsAddr address;
+        auto error = AdsGetLocalAddressEx(m_Port, &address);
+        if (error) {throw AdsException(error); }
+        return address;
+    }
+
+    // Timeout
+    const uint32_t GetTimeout() const
+    {
+        uint32_t timeout = 0;
+        uint32_t error = AdsSyncGetTimeoutEx(m_Port, &timeout);
+        if (error) {throw AdsException(error); }
+        return timeout;
+    }
+    void SetTimeout(const uint32_t timeout) const
+    {
+        uint32_t error = AdsSyncSetTimeoutEx(m_Port, timeout);
+        if (error) {throw AdsException(error); }
+    }
+
+    // Device info
+    const DeviceInfo ReadDeviceInfo(const AmsAddr& address) const
+    {
+        DeviceInfo deviceInfo;
+        auto error = AdsSyncReadDeviceInfoReqEx(m_Port, &address, deviceInfo.name, &deviceInfo.version);
+        if (error) {throw AdsException(error); }
+        return deviceInfo;
+    }
+
+    // Read variables by symbolic name
+    template<typename T>
+    const AdsReadResponse<T> Read(
+        const AmsAddr&     address,
+        const std::string& symbolName) const
+    {
+        auto handle = GetHandle(address, symbolName.c_str());
+        AdsReadResponse<T> response;
+        uint32_t bytesRead = 0;
+        auto error = AdsSyncReadReqEx2(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_VALBYHND,
+            handle,
+            sizeof(T),
+            response.GetPointer(),
+            &bytesRead);
+        ReleaseHandle(address, handle);
+        if (error) {throw AdsException(error); }
+        response.SetBytesRead(bytesRead);
+        return response;
+    }
+
+    // Read variables by index group and index offset
+    template<typename T>
+    const AdsReadResponse<T> Read(
+        const AmsAddr& address,
+        const uint32_t indexGroup,
+        const uint32_t indexOffset) const
+    {
+        AdsReadResponse<T> response;
+        uint32_t bytesRead = 0;
+
+        auto error = AdsSyncReadReqEx2(
+            m_Port,
+            &address,
+            indexGroup,
+            indexOffset,
+            sizeof(T),
+            response.GetPointer(),
+            &bytesRead);
+        if (error) {throw AdsException(error); }
+        response.SetBytesRead(bytesRead);
+        return response;
+    }
+
+    // Read arrays by symbolic name
+    template<typename T, uint32_t count = 1>
+    const AdsReadArrayResponse<T, count> ReadArray(
+        const AmsAddr&     address,
+        const std::string& symbolName) const
+    {
+        auto handle = GetHandle(address, symbolName.c_str());
+        AdsReadArrayResponse<T, count> response;
+        uint32_t bytesRead = 0;
+
+        auto error = AdsSyncReadReqEx2(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_VALBYHND,
+            handle,
+            sizeof(T) * count,
+            response.GetPointer(),
+            &bytesRead);
+        ReleaseHandle(address, handle);
+        if (error) {throw AdsException(error); }
+        response.SetBytesRead(bytesRead);
+        return response;
+    }
+
+    // Read arrays by index group and index offset
+    template<typename T, uint32_t count = 1>
+    const AdsReadArrayResponse<T, count> ReadArray(
+        const AmsAddr& address,
+        const uint32_t indexGroup,
+        const uint32_t indexOffset) const
+    {
+        AdsReadArrayResponse<T, count> response;
+        uint32_t bytesRead = 0;
+
+        auto error = AdsSyncReadReqEx2(
+            m_Port,
+            &address,
+            indexGroup,
+            indexOffset,
+            sizeof(T) * count,
+            response.GetPointer(),
+            &bytesRead);
+        if (error) {throw AdsException(error); }
+        response.SetBytesRead(bytesRead);
+        return response;
+    }
+
+    // Write variable by symbolic name
+    template<typename T, uint32_t count = 1> void Write(
+        const AmsAddr&     address,
+        const std::string& symbolName,
+        const T&           value)
+    {
+        auto handle = GetHandle(address, symbolName.c_str());
+        auto error = AdsSyncWriteReqEx(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_VALBYHND,
+            handle,
+            sizeof(T) * count,
+            &value);
+        ReleaseHandle(address, handle);
+        if (error) {throw AdsException(error); }
+    }
+
+    // Write variable by index group and index offset
+    template<typename T, uint32_t count = 1> void Write(
+        const AmsAddr& address,
+        const uint32_t indexGroup,
+        const uint32_t indexOffset,
+        const T&       value)
+    {
+        auto error = AdsSyncWriteReqEx(
+            m_Port,
+            &address,
+            indexGroup,
+            indexOffset,
+            sizeof(T) * count,
+            &value
+            );
+        if (error) {throw AdsException(error); }
+    }
+
+    // Write array by symbolic name
+    template<typename T, uint32_t count = 1> void WriteArray(
+        const AmsAddr&     address,
+        const std::string& symbolName,
+        const T*           pValue)
+    {
+        auto handle = GetHandle(address, symbolName.c_str());
+        auto error = AdsSyncWriteReqEx(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_VALBYHND,
+            handle,
+            sizeof(T) * count,
+            pValue);
+        ReleaseHandle(address, handle);
+        if (error) {throw AdsException(error); }
+    }
+
+    // Write array by index group and index offset
+    template<typename T, uint32_t count = 1> void WriteArray(
+        const AmsAddr& address,
+        const uint32_t indexGroup,
+        const uint32_t indexOffset,
+        const T*       pValue)
+    {
+        auto error = AdsSyncWriteReqEx(
+            m_Port,
+            &address,
+            indexGroup,
+            indexOffset,
+            sizeof(T) * count,
+            pValue
+            );
+        if (error) {throw AdsException(error); }
+    }
+
+private:
+    uint32_t m_Port;
+
+    // Get the handle for a given symbol name
+    const uint32_t GetHandle(
+        const AmsAddr&    address,
+        const char* const symbolName) const
+    {
+        uint32_t handle = 0;
+        uint32_t bytesRead = 0;
+        uint32_t error = AdsSyncReadWriteReqEx2(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_HNDBYNAME, 0,
+            sizeof(handle), &handle,
+            strlen(symbolName),
+            (void*)symbolName,
+            &bytesRead
+            );
+
+        if (error || (sizeof(handle) != bytesRead)) {
+            throw AdsException(error);
+        }
+        return handle;
+    }
+
+    // Release a given handle
+    void ReleaseHandle(
+        const AmsAddr& address,
+        const uint32_t     handle) const
+    {
+        uint32_t error = AdsSyncWriteReqEx(
+            m_Port,
+            &address,
+            ADSIGRP_SYM_RELEASEHND, 0,
+            sizeof(handle), &handle
+            );
+
+        if (error) {
+            throw AdsException(error);
+        }
+    }
+};
+
+#endif

--- a/example/AdsClient/AdsException.h
+++ b/example/AdsClient/AdsException.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <stdexcept>
+#include <string>
+
+class AdsException : public std::exception {
+public:
+    AdsException(const long adsErrorCode) :
+        m_AdsErrorCode(adsErrorCode),
+        m_Message("Ads operation failed with error code " + std::to_string(adsErrorCode) + ".")
+    {}
+
+    virtual ~AdsException() throw (){}
+
+    virtual const char* what() const throw ()
+    {
+        return m_Message.c_str();
+    }
+
+    const long getErrorCode() const
+    {
+        return m_AdsErrorCode;
+    }
+
+protected:
+    const long m_AdsErrorCode;
+    const std::string m_Message;
+};

--- a/example/AdsClient/AdsReadArrayResponse.h
+++ b/example/AdsClient/AdsReadArrayResponse.h
@@ -1,0 +1,62 @@
+/**
+    Class which is returned by the AdsClient ReadArray()-Operations.
+ */
+
+#pragma once
+
+#include <stdexcept>
+
+template<typename T, uint32_t count>
+class AdsReadArrayResponse {
+public:
+    AdsReadArrayResponse<T, count>()
+    {
+        m_pArray = std::shared_ptr<T>(new T[count], array_deleter<T>());
+        m_BytesRead = 0;
+    }
+
+    const T* Get() const
+    {
+        return m_pArray.get();
+    }
+
+    T* GetPointer() const
+    {
+        return m_pArray.get();
+    }
+
+    const uint32_t GetBytesRead() const
+    {
+        return m_BytesRead;
+    }
+
+    void SetBytesRead(const uint32_t bytesRead)
+    {
+        m_BytesRead = bytesRead;
+    }
+
+    const uint32_t GetElementsRead() const
+    {
+        return m_BytesRead / sizeof(T);
+    }
+
+    T operator[](uint32_t index)
+    {
+        if (index < m_BytesRead / sizeof(T)) {
+            return m_pArray.get()[index];
+        } else { throw std::out_of_range("The requested index is not inside the range of elements read from the server"); }
+    }
+
+private:
+    std::shared_ptr<T> m_pArray;
+    uint32_t m_BytesRead;
+
+    template<typename T1>
+    class array_deleter {
+    public:
+        void operator()(T1 const* p)
+        {
+            delete[] p;
+        }
+    };
+};

--- a/example/AdsClient/AdsReadResponse.h
+++ b/example/AdsClient/AdsReadResponse.h
@@ -1,0 +1,45 @@
+/**
+    Class which is returned by the AdsClient Read()-Operations.
+ */
+
+#pragma once
+
+#include <memory>
+
+template<typename T>
+class AdsReadResponse {
+public:
+    AdsReadResponse<T>()
+    {
+        m_pValue = std::shared_ptr<T>(new T);
+    }
+
+    const T& Get() const
+    {
+        return *m_pValue;
+    }
+
+    T* GetPointer() const
+    {
+        return m_pValue.get();
+    }
+
+    void SetBytesRead(const uint32_t bytesRead)
+    {
+        m_BytesRead = bytesRead;
+    }
+
+    const uint32_t GetBytesRead() const
+    {
+        return m_BytesRead;
+    }
+
+    operator T() const
+    {
+        return *m_pValue;
+    }
+
+private:
+    std::shared_ptr<T> m_pValue;
+    uint32_t m_BytesRead;
+};


### PR DESCRIPTION
Hi,

I proposed an object-oriented interface for the library earlier.
This is my first shot.

My attention was to reduce the hassle of using the current interface.
For me, the major drawbacks of the original library are:

1) Handling of memory buffers
2) Function call order (OpenPort, Do something, close port)
3) Too many parameters for function calls 
4) Error codes

I tried to solve them like this:
1) Using shared_ptr to allocate memory internally
2) Using RAII
3) Use the type system to deduce type sizes and return values instead of output parameters
4) Generate exceptions instead of returning error codes

The whole thing is a header-only addition to make it easy to include.
Every feedback is welcome. 

Regards
Michael