### PR TITLE
Sockets: LOG_INFO Connected to

### DIFF
--- a/AdsLib/Sockets.cpp
+++ b/AdsLib/Sockets.cpp
@@ -205,6 +205,9 @@ uint32_t TcpSocket::Connect() const
         LOG_ERROR("Read local tcp/ip address failed");
         return 0;
     }
+    LOG_INFO(" Connected to " << ((addr & 0xff000000) >> 24) << '.' << ((addr & 0xff0000) >> 16) << '.' <<
+             ((addr & 0xff00) >> 8) << '.' << (addr & 0xff));
+
     return ntohl(source.sin_addr.s_addr);
 }
 


### PR DESCRIPTION
When connecting to the ADS system in Sockets.cpp there is
a LOG_INFO giving "Info: Connecting to 192.168.1.2"
When the connection fails, there is a LOG_ERROR.

When the connection succeeds, there is no printout, leaving the
user in a state of user in a state of uncertainty.
Add a LOG_INFO that show the successful connection like this:
"Info:  Connected to 192.168.1.2"