### PR TITLE
added virtual destructor for AmsProxy interface

### DIFF
--- a/AdsLib/NotificationDispatcher.h
+++ b/AdsLib/NotificationDispatcher.h
@@ -32,6 +32,7 @@
 
 struct AmsProxy {
     virtual long DeleteNotification(const AmsAddr& amsAddr, uint32_t hNotify, uint32_t tmms, uint16_t port) = 0;
+    virtual ~AmsProxy() {}
 };
 
 struct NotificationDispatcher {


### PR DESCRIPTION
this fixes delete-non-virtual-dtor warning