### PR TITLE
Makefile: Use make env-variable `OS` for os detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 
-OS_NAME ?=$(shell uname)
+ifeq ($(OS),Windows_NT)     # XP, 2000, 7, Vista, 10...
+    OS_NAME := win32
+else
+    OS_NAME ?= $(shell uname)
+endif
 VPATH = AdsLib
 LIBS = -lpthread
 LIB_NAME = AdsLib-$(OS_NAME).a


### PR DESCRIPTION
...with fallback to `uname` on non-Windows OSs.