### PR TITLE
Replace memcpy and memcmp with assignement and compare operators

### DIFF
--- a/AdsLib/AdsDef.cpp
+++ b/AdsLib/AdsDef.cpp
@@ -29,7 +29,8 @@
 
 bool operator<(const AmsAddr& lhs, const AmsAddr& rhs)
 {
-    if (memcmp(&lhs.netId, &rhs.netId, sizeof(lhs.netId))) {
+    //// if (memcmp(&lhs.netId, &rhs.netId, sizeof(lhs.netId))) {
+    if (lhs.netId != rhs.netId) {
         return lhs.netId < rhs.netId;
     }
     return lhs.port < rhs.port;
@@ -63,6 +64,54 @@ AmsNetId::AmsNetId(uint8_t id_0, uint8_t id_1, uint8_t id_2, uint8_t id_3, uint8
 
 AmsNetId::AmsNetId(const std::string& addr)
 {
+	assign(addr);
+}
+
+AmsNetId::AmsNetId(const AmsNetId& rhs)
+{
+	assign(rhs);
+}
+
+
+bool AmsNetId::operator == (const AmsNetId& rhs) const
+{
+	return 0 == memcmp(b, rhs.b, sizeof(rhs.b));
+}
+
+bool AmsNetId::operator != (const AmsNetId& rhs) const
+{
+	return 0 != memcmp(b, rhs.b, sizeof(rhs.b));
+}
+
+bool AmsNetId::operator < (const AmsNetId& rhs) const
+{
+    for (unsigned int i = 0; i < sizeof(rhs.b); ++i) {
+        if (b[i] != rhs.b[i]) {
+            return b[i] < rhs.b[i];
+        }
+    }
+    return false;
+}
+
+AmsNetId& AmsNetId::operator = (const std::string& addr)
+{
+	assign(addr);
+	return *this;
+}
+
+AmsNetId& AmsNetId::operator = (const AmsNetId& rhs)
+{
+	assign(rhs);
+	return *this;
+}
+
+void AmsNetId::assign(const AmsNetId& rhs)
+{
+    memcpy(b, rhs.b, sizeof(b));
+}
+
+void AmsNetId::assign(const std::string& addr)
+{
     std::istringstream iss(addr);
     std::string s;
     size_t i = 0;
@@ -78,18 +127,14 @@ AmsNetId::AmsNetId(const std::string& addr)
     }
 }
 
-bool AmsNetId::operator<(const AmsNetId& rhs) const
+bool AmsNetId::isValid() const
 {
-    for (unsigned int i = 0; i < sizeof(rhs.b); ++i) {
-        if (b[i] != rhs.b[i]) {
-            return b[i] < rhs.b[i];
-        }
-    }
-    return false;
+	static const AmsNetId empty {};
+    return 0 != memcmp(b, &empty.b, sizeof(b));
 }
 
 AmsNetId::operator bool() const
 {
-    static const AmsNetId empty {};
-    return 0 != memcmp(b, &empty.b, sizeof(b));
+    return isValid();
 }
+

--- a/AdsLib/AdsDef.cpp
+++ b/AdsLib/AdsDef.cpp
@@ -63,26 +63,25 @@ AmsNetId::AmsNetId(uint8_t id_0, uint8_t id_1, uint8_t id_2, uint8_t id_3, uint8
 
 AmsNetId::AmsNetId(const std::string& addr)
 {
-	assign(addr);
+    assign(addr);
 }
 
 AmsNetId::AmsNetId(const AmsNetId& rhs)
 {
-	assign(rhs);
+    assign(rhs);
 }
 
-
-bool AmsNetId::operator == (const AmsNetId& rhs) const
+bool AmsNetId::operator==(const AmsNetId& rhs) const
 {
-	return 0 == memcmp(b, rhs.b, sizeof(rhs.b));
+    return 0 == memcmp(b, rhs.b, sizeof(rhs.b));
 }
 
 bool AmsNetId::operator != (const AmsNetId& rhs) const
 {
-	return 0 != memcmp(b, rhs.b, sizeof(rhs.b));
+    return 0 != memcmp(b, rhs.b, sizeof(rhs.b));
 }
 
-bool AmsNetId::operator < (const AmsNetId& rhs) const
+bool AmsNetId::operator<(const AmsNetId& rhs) const
 {
     for (unsigned int i = 0; i < sizeof(rhs.b); ++i) {
         if (b[i] != rhs.b[i]) {
@@ -92,16 +91,16 @@ bool AmsNetId::operator < (const AmsNetId& rhs) const
     return false;
 }
 
-AmsNetId& AmsNetId::operator = (const std::string& addr)
+AmsNetId& AmsNetId::operator=(const std::string& addr)
 {
-	assign(addr);
-	return *this;
+    assign(addr);
+    return *this;
 }
 
-AmsNetId& AmsNetId::operator = (const AmsNetId& rhs)
+AmsNetId& AmsNetId::operator=(const AmsNetId& rhs)
 {
-	assign(rhs);
-	return *this;
+    assign(rhs);
+    return *this;
 }
 
 void AmsNetId::assign(const AmsNetId& rhs)
@@ -128,7 +127,7 @@ void AmsNetId::assign(const std::string& addr)
 
 bool AmsNetId::isValid() const
 {
-	static const AmsNetId empty {};
+    static const AmsNetId empty {};
     return 0 != memcmp(b, &empty.b, sizeof(b));
 }
 

--- a/AdsLib/AdsDef.cpp
+++ b/AdsLib/AdsDef.cpp
@@ -29,7 +29,6 @@
 
 bool operator<(const AmsAddr& lhs, const AmsAddr& rhs)
 {
-    //// if (memcmp(&lhs.netId, &rhs.netId, sizeof(lhs.netId))) {
     if (lhs.netId != rhs.netId) {
         return lhs.netId < rhs.netId;
     }

--- a/AdsLib/AdsDef.h
+++ b/AdsLib/AdsDef.h
@@ -245,14 +245,25 @@ struct AmsNetId {
     /** NetId, consisting of 6 digits. */
     uint8_t b[6];
 
-#ifdef __cplusplus
+    void assign(const AmsNetId& rhs);
+    void assign(const std::string& addr);
+
+    bool operator==(const AmsNetId& rhs) const;
+    bool operator!=(const AmsNetId& rhs) const;
+    bool operator<(const AmsNetId& rhs) const;
+
+    AmsNetId& operator=(const AmsNetId& rhs);
+    AmsNetId& operator=(const std::string& addr);
+
+    bool isValid() const;
+    operator bool() const;
+
     AmsNetId(uint32_t ipv4Addr = 0);
     AmsNetId(const std::string& addr);
+    AmsNetId(const AmsNetId& rhs);
     AmsNetId(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t);
-    bool operator<(const AmsNetId& rhs) const;
-    operator bool() const;
-#endif
 };
+
 
 /**
  * @brief The complete address of an ADS device can be stored in this structure.

--- a/AdsLib/AdsDef.h
+++ b/AdsLib/AdsDef.h
@@ -245,6 +245,7 @@ struct AmsNetId {
     /** NetId, consisting of 6 digits. */
     uint8_t b[6];
 
+#ifdef __cplusplus
     void assign(const AmsNetId& rhs);
     void assign(const std::string& addr);
 
@@ -262,6 +263,7 @@ struct AmsNetId {
     AmsNetId(const std::string& addr);
     AmsNetId(const AmsNetId& rhs);
     AmsNetId(uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t);
+#endif
 };
 
 

--- a/AdsLib/AmsPort.cpp
+++ b/AdsLib/AmsPort.cpp
@@ -26,7 +26,7 @@ namespace std
 {
 bool operator==(const AmsAddr& lhs, const AmsAddr& rhs)
 {
-    return 0 == memcmp(&lhs, &rhs, sizeof(lhs));
+    return lhs.netId == rhs.netId && lhs.port == rhs.port;
 }
 }
 

--- a/AdsLib/AmsRouter.cpp
+++ b/AdsLib/AmsRouter.cpp
@@ -113,7 +113,7 @@ long AmsRouter::GetLocalAddress(uint16_t port, AmsAddr* pAddr)
     }
 
     if (ports[port - PORT_BASE].IsOpen()) {
-        memcpy(&pAddr->netId, &localAddr, sizeof(localAddr));
+        pAddr->netId = localAddr;
         pAddr->port = port;
         return 0;
     }

--- a/AdsLib/Router.h
+++ b/AdsLib/Router.h
@@ -26,6 +26,8 @@
 #include "AdsDef.h"
 
 struct Router {
+	virtual ~Router() {};
+
     static const size_t NUM_PORTS_MAX = 128;
     static const uint16_t PORT_BASE = 30000;
     static_assert(NUM_PORTS_MAX + PORT_BASE <= UINT16_MAX, "Port limit is out of range");

--- a/AdsLib/Router.h
+++ b/AdsLib/Router.h
@@ -26,8 +26,6 @@
 #include "AdsDef.h"
 
 struct Router {
-	virtual ~Router() {};
-
     static const size_t NUM_PORTS_MAX = 128;
     static const uint16_t PORT_BASE = 30000;
     static_assert(NUM_PORTS_MAX + PORT_BASE <= UINT16_MAX, "Port limit is out of range");


### PR DESCRIPTION
Replace memcpy and memcmp with assignement and compare operators in class AmsNetId.