### PR TITLE
Implement CMake-Buildsystem for Beckhoff ADS.

### DIFF
--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.13)
+
+set(SOURCES
+  AdsDef.cpp
+  AdsDevice.cpp
+  AdsLib.cpp
+  AdsNotification.cpp
+  AmsConnection.cpp
+  AmsPort.cpp
+  AmsRouter.cpp
+  Log.cpp
+  NotificationDispatcher.cpp
+  Sockets.cpp
+  Frame.cpp
+)
+
+add_library(ads ${SOURCES})
+
+target_include_directories(ads INTERFACE .)
+
+target_compile_features(ads PRIVATE
+  cxx_std_11
+)
+
+target_compile_options(ads PRIVATE
+  -pedantic
+  -Wall
+  -Wextra
+)
+
+target_compile_definitions(ads PRIVATE
+  _GNU_SOURCE
+)

--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -1,18 +1,14 @@
 cmake_minimum_required(VERSION 3.13)
 
 set(SOURCES
-  AdsDef.cpp
   AdsDevice.cpp
-  AdsLib.cpp
-  AdsNotification.cpp
-  AmsConnection.cpp
-  AmsPort.cpp
-  AmsRouter.cpp
+  AdsDef.cpp
   Log.cpp
-  NotificationDispatcher.cpp
   Sockets.cpp
   Frame.cpp
 )
+
+add_subdirectory(standalone)
 
 add_library(ads ${SOURCES})
 

--- a/AdsLib/standalone/CMakeLists.txt
+++ b/AdsLib/standalone/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.13)
+
+set(SOURCES
+  AdsLib.cpp
+  AmsConnection.cpp
+  AmsNetId.cpp
+  AmsPort.cpp
+  AmsRouter.cpp
+  NotificationDispatcher.cpp
+)
+
+add_library(ads_standalone ${SOURCES})
+
+target_include_directories(ads_standalone PUBLIC ..)
+
+target_link_libraries(ads_standalone ads)

--- a/AdsLibTest/CMakeLists.txt
+++ b/AdsLibTest/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(ads-test)
+
+set(SOURCES
+  main.cpp
+)
+
+add_executable(AdsLibTest.bin ${SOURCES})
+
+target_link_libraries(AdsLibTest.bin ads pthread)
+
+target_include_directories(AdsLibTest.bin
+  PRIVATE ${PROJECT_SOURCE_DIR}/../tools/
+)
+
+target_compile_features(AdsLibTest.bin PRIVATE
+  cxx_std_11
+)
+
+target_compile_options(AdsLibTest.bin PRIVATE
+  -pedantic
+  -Wall
+  -Wextra
+)
+
+target_compile_definitions(AdsLibTest.bin PRIVATE
+  _GNU_SOURCE
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(ads)
+
+
+add_subdirectory(AdsLib)
+add_subdirectory(AdsLibTest)
+add_subdirectory(example)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(example)
+
+set(SOURCES
+  example.cpp
+)
+
+add_executable(example.bin ${SOURCES})
+
+target_link_libraries(example.bin ads pthread)
+
+target_compile_features(example.bin PRIVATE
+  cxx_std_11
+)
+
+target_compile_options(example.bin PRIVATE
+  -pedantic
+  -Wall
+  -Wextra
+)
+
+target_compile_definitions(example.bin PRIVATE
+  _GNU_SOURCE
+)


### PR DESCRIPTION
Added build files for CMake to ease integration with projects using CMake.