### PR TITLE
fix byte order issue of symbol handle by name

### DIFF
--- a/AdsLib/AdsDevice.cpp
+++ b/AdsLib/AdsDevice.cpp
@@ -6,6 +6,7 @@
 #include "AdsDevice.h"
 #include "AdsException.h"
 #include "AdsLib.h"
+#include "wrap_endian.h"
 
 static AmsNetId* AddRoute(AmsNetId ams, const char* ip)
 {
@@ -74,6 +75,8 @@ AdsHandle AdsDevice::GetHandle(const std::string& symbolName) const
     if (error || (sizeof(handle) != bytesRead)) {
         throw AdsException(error);
     }
+
+    handle = qToLittleEndian(handle);
 
     return {new uint32_t {handle}, {std::bind(&AdsDevice::DeleteSymbolHandle, this, std::placeholders::_1)}};
 }

--- a/AdsLib/AdsNotificationOOI.h
+++ b/AdsLib/AdsNotificationOOI.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AdsDevice.h"
+#include "wrap_endian.h"
 
 typedef void (* PAdsNotificationFuncExConst)(const AmsAddr* pAddr, const AdsNotificationHeader* pNotification,
                                              uint32_t hUser);
@@ -13,7 +14,7 @@ struct AdsNotification {
                     PAdsNotificationFuncExConst  callback,
                     uint32_t                     hUser)
         : m_Symbol(route.GetHandle(symbolName)),
-        m_Notification(route.GetHandle(ADSIGRP_SYM_VALBYHND, *m_Symbol, notificationAttributes,
+        m_Notification(route.GetHandle(ADSIGRP_SYM_VALBYHND, qToLittleEndian<uint32_t>(*m_Symbol), notificationAttributes,
                                        reinterpret_cast<PAdsNotificationFuncEx>(callback), hUser))
     {}
 
@@ -23,7 +24,7 @@ struct AdsNotification {
                     PAdsNotificationFuncExLegacy callback,
                     uint32_t                     hUser)
         : m_Symbol(route.GetHandle(symbolName)),
-        m_Notification(route.GetHandle(ADSIGRP_SYM_VALBYHND, *m_Symbol, notificationAttributes,
+        m_Notification(route.GetHandle(ADSIGRP_SYM_VALBYHND, qToLittleEndian<uint32_t>(*m_Symbol), notificationAttributes,
                                        reinterpret_cast<PAdsNotificationFuncEx>(callback), hUser))
     {}
 

--- a/AdsLib/AdsNotificationOOI.h
+++ b/AdsLib/AdsNotificationOOI.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "AdsDevice.h"
-#include "wrap_endian.h"
 
 typedef void (* PAdsNotificationFuncExConst)(const AmsAddr* pAddr, const AdsNotificationHeader* pNotification,
                                              uint32_t hUser);
@@ -14,7 +13,7 @@ struct AdsNotification {
                     PAdsNotificationFuncExConst  callback,
                     uint32_t                     hUser)
         : m_Symbol(route.GetHandle(symbolName)),
-        m_Notification(route.GetHandle(ADSIGRP_SYM_VALBYHND, qToLittleEndian<uint32_t>(*m_Symbol), notificationAttributes,
+        m_Notification(route.GetHandle(ADSIGRP_SYM_VALBYHND, *m_Symbol, notificationAttributes,
                                        reinterpret_cast<PAdsNotificationFuncEx>(callback), hUser))
     {}
 
@@ -24,7 +23,7 @@ struct AdsNotification {
                     PAdsNotificationFuncExLegacy callback,
                     uint32_t                     hUser)
         : m_Symbol(route.GetHandle(symbolName)),
-        m_Notification(route.GetHandle(ADSIGRP_SYM_VALBYHND, qToLittleEndian<uint32_t>(*m_Symbol), notificationAttributes,
+        m_Notification(route.GetHandle(ADSIGRP_SYM_VALBYHND, *m_Symbol, notificationAttributes,
                                        reinterpret_cast<PAdsNotificationFuncEx>(callback), hUser))
     {}
 


### PR DESCRIPTION
After some tests I found an other issue with `AdsVariable` by symbolName.
So I decided to change the byte order of the handle directly in AdsDevice.cpp to fix both issues with a single line of code.
It is up to you to accept this pull request or to find a better solution.