### PR TITLE
reduze required CMake version for Ubuntu bionic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.10.2)
 
 project(ads)
 


### PR DESCRIPTION
Ubuntu Bionic/ 18.04 comes with CMake 3.10.2 by default. As I didn't see anything special in the CMakeLists.txt I'm proposing to relax this requirement a bit.

Any reason for picking 3.13 in your initial contribution @miq 