### PR TITLE
compatibility with CMake 3.10.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     -Wall
     -Wextra
   )
-  add_compile_definitions(_GNU_SOURCE)
+  add_definitions(-D_GNU_SOURCE)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # Compiler flags and definitions for Visual Studio come here
 endif()


### PR DESCRIPTION
add_compile_definitions requires 3.12, I overlooked that in #144 unfortunately