### PR TITLE
Fix link error msvc 2019

### DIFF
--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -16,4 +16,9 @@ add_library(ads ${SOURCES})
 
 target_include_directories(ads PUBLIC .)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  target_link_libraries(ads PRIVATE wsock32 ws2_32)
+endif()
+
+
 target_link_libraries(ads PUBLIC Threads::Threads)


### PR DESCRIPTION
* The visual studio 2019 C++ compiler needs to link with winsocket lib.