### PR TITLE
cmake: Make Windows's winsock2 link libraries a public dependency

### DIFF
--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -17,8 +17,7 @@ add_library(ads ${SOURCES})
 target_include_directories(ads PUBLIC .)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_link_libraries(ads PRIVATE wsock32 ws2_32)
+  target_link_libraries(ads PUBLIC wsock32 ws2_32)
 endif()
-
 
 target_link_libraries(ads PUBLIC Threads::Threads)


### PR DESCRIPTION
This fixes linking of the executables (adstool, example), as well as any other consumers of adstool, even outside this repo, on Windows.