### PR TITLE
Standalone DLL with C interface

### DIFF
--- a/AdsLib/AdsLib.cpp
+++ b/AdsLib/AdsLib.cpp
@@ -3,6 +3,7 @@
    Copyright (c) 2021 Beckhoff Automation GmbH & Co. KG
  */
 
+#include "AdsDef.h"
 #include "AdsLib.h"
 #include "Log.h"
 #include "wrap_endian.h"
@@ -170,5 +171,39 @@ long GetRemoteAddress(const IpV4 remote, AmsNetId& netId)
     memcpy(&netId, f.data(), sizeof(netId));
     return 0;
 }
+}  // namespace ads
+}  // namespace bhf
+
+
+long AdsAddRemoteRoute(const char *remote,
+                    const char *destNetId,
+                    const char *destAddr,
+                    const char *routeName,
+                    const char *remoteUsername,
+                    const char *remotePassword
+)
+{
+    return bhf::ads::AddRemoteRoute(
+        IpV4(std::string(remote)),
+        make_AmsNetId(destNetId),
+        destAddr,
+        routeName,
+        remoteUsername,
+        remotePassword
+    );
 }
+
+long AdsAddRoute(const char *ams, const char *ip)
+{
+    return bhf::ads::AddLocalRoute(AmsNetId {ams}, ip);
+}
+
+void AdsSetLocalAddress(const char *netId)
+{
+    bhf::ads::SetLocalAddress(AmsNetId {netId});
+}
+
+void AdsDelRoute(const char *ams)
+{
+    bhf::ads::DelLocalRoute(AmsNetId {ams});
 }

--- a/AdsLib/AdsLib.h
+++ b/AdsLib/AdsLib.h
@@ -12,6 +12,10 @@
 
 #include "Sockets.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Reads data synchronously from an ADS server.
  * @param[in] port port number of an Ads port that had previously been opened with AdsPortOpenEx().
@@ -148,6 +152,27 @@ long AdsSyncDelDeviceNotificationReqEx(long port, const AmsAddr* pAddr, uint32_t
  */
 long AdsSyncGetTimeoutEx(long port, uint32_t* timeout);
 
+/** Plain C interface to bhf::ads::AddRemoteRoute */
+long AdsAddRemoteRoute(const char *remote,
+                    const char *destNetId,
+                    const char *destAddr,
+                    const char *routeName,
+                    const char *remoteUsername,
+                    const char *remotePassword);
+
+/** Plain C interface to bhf::ads::AddLocalRoute */
+long AdsAddRoute(const char *ams, const char* ip);
+
+/** Plain C interface to bhf::ads::SetLocalAddress */
+void AdsSetLocalAddress(const char *netId);
+
+/** Plain C interface to  bhf::ads::DelLocalRoute */
+void AdsDelRoute(const char *ams);
+
+#ifdef __cplusplus
+}
+#endif
+
 namespace bhf
 {
 namespace ads
@@ -199,7 +224,3 @@ long GetRemoteAddress(const IpV4 remote,
                       AmsNetId&  netId);
 }
 }
-
-#define AdsAddRoute bhf::ads::AddLocalRoute
-#define AdsDelRoute bhf::ads::DelLocalRoute
-#define AdsSetLocalAddress bhf::ads::SetLocalAddress

--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -1,9 +1,15 @@
 set(SOURCES
-  AdsDevice.cpp
   AdsDef.cpp
-  Log.cpp
-  Sockets.cpp
+  AdsDevice.cpp
+  AdsFile.cpp
+  AdsLib.cpp
   Frame.cpp
+  LicenseAccess.cpp
+  Log.cpp
+  RouterAccess.cpp
+  RTimeAccess.cpp
+  Sockets.cpp
+
   standalone/AdsLib.cpp
   standalone/AmsConnection.cpp
   standalone/AmsNetId.cpp
@@ -16,9 +22,8 @@ add_library(ads ${SOURCES})
 
 target_include_directories(ads PUBLIC .)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_link_libraries(ads PRIVATE wsock32 ws2_32)
+if(${WIN32} EQUAL 1)
+    target_link_libraries(ads PUBLIC ws2_32)
 endif()
-
 
 target_link_libraries(ads PUBLIC Threads::Threads)

--- a/AdsLib/standalone/AdsLib.cpp
+++ b/AdsLib/standalone/AdsLib.cpp
@@ -42,6 +42,7 @@ static AmsRouter& GetRouter()
         } \
 } while (false)
 
+
 namespace bhf
 {
 namespace ads
@@ -66,8 +67,12 @@ void SetLocalAddress(const AmsNetId ams)
 {
     GetRouter().SetLocalAddress(ams);
 }
-}
-}
+}  // namespace ads
+}  // namespace bhf
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 long AdsPortCloseEx(long port)
 {
@@ -338,3 +343,7 @@ long AdsSyncSetTimeoutEx(long port, uint32_t timeout)
     ASSERT_PORT(port);
     return GetRouter().SetTimeout((uint16_t)port, timeout);
 }
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif

--- a/AdsLib/standalone/AdsLib.h
+++ b/AdsLib/standalone/AdsLib.h
@@ -6,6 +6,11 @@
 
 #include "AdsDef.h"
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * The connection (communication port) to the message router is
  * closed. The port to be closed must previously have been opened via
@@ -38,3 +43,7 @@ long AdsGetLocalAddressEx(long port, AmsAddr* pAddr);
  * @return [ADS Return Code](https://infosys.beckhoff.com/content/1031/tcadscommon/html/ads_returncodes.htm?id=1666172286265530469)
  */
 long AdsSyncSetTimeoutEx(long port, uint32_t timeout);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # Compiler flags and definitions for Visual Studio come here
 endif()
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
 add_subdirectory(AdsLib)
 add_subdirectory(AdsLibTest)
 add_subdirectory(example)


### PR DESCRIPTION
Plain C functions in the library should be accessible using C interface (no name mangling). Also some files were missing in CMakeLists.txt.
Tested on win64/gcc11/cmake