### PR TITLE
Enable TwinCAT router support via cmake build + minor cleanups

### DIFF
--- a/AdsLib/AdsNotification.h
+++ b/AdsLib/AdsNotification.h
@@ -38,7 +38,7 @@ struct Notification {
             data[i] = ring.ReadFromLittleEndian<uint8_t>();
         }
         header->nTimeStamp = timestamp;
-        callback(&connection.second, header, hUser);
+        callback(const_cast<AmsAddr*>(&connection.second), header, hUser);
     }
 
     uint32_t Size() const

--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -1,31 +1,34 @@
-set(SOURCES
-  AdsDef.cpp
-  AdsDevice.cpp
-  AdsFile.cpp
-  AdsLib.cpp
-  Frame.cpp
-  LicenseAccess.cpp
-  Log.cpp
-  RouterAccess.cpp
-  RTimeAccess.cpp
-  Sockets.cpp
+file(GLOB BASE_SOURCES LIST_DIRECTORIES false CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
+file(GLOB_RECURSE MY_HEADERS "${CMAKE_CURRENT_LIST_DIR}/*.h")
 
-  standalone/AdsLib.cpp
-  standalone/AmsConnection.cpp
-  standalone/AmsNetId.cpp
-  standalone/AmsPort.cpp
-  standalone/AmsRouter.cpp
-  standalone/NotificationDispatcher.cpp
+if (ADS_USE_TWINCAT_ROUTER STREQUAL "ON")
+    if (NOT DEFINED ENV{TWINCAT3DIR}) 
+        message(FATAL_ERROR "Expected TWINCAT3DIR env-var to be set. Please install TwinCAT/XAE!")
+    endif()
+    file(GLOB ROUTER_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/TwinCAT/*.cpp")
+else ()
+    file(GLOB ROUTER_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/standalone/*.cpp")
+endif()
+
+add_library(ads
+    ${BASE_SOURCES}
+    ${ROUTER_SOURCES}
+    ${MY_HEADERS}
 )
-
-add_library(ads ${SOURCES})
 
 target_include_directories(ads PUBLIC .)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_link_libraries(ads PUBLIC wsock32)
+if (ADS_USE_TWINCAT_ROUTER STREQUAL "ON")
+    target_compile_definitions(ads PUBLIC USE_TWINCAT_ROUTER)
+    target_include_directories(ads PUBLIC "$ENV{TWINCAT3DIR}\\..\\AdsApi\\TcAdsDll\\include")
+    target_link_libraries(ads PUBLIC "$ENV{TWINCAT3DIR}\\..\\AdsApi\\TcAdsDll\\x64\\lib\\TcAdsDll.lib")
 endif()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  target_link_libraries(ads PUBLIC wsock32)
+else()
+  target_compile_options(ads PUBLIC -fPIC)
+endif()
 
 if(WIN32 EQUAL 1)
     target_link_libraries(ads PUBLIC ws2_32)

--- a/AdsLib/RouterAccess.cpp
+++ b/AdsLib/RouterAccess.cpp
@@ -29,18 +29,18 @@ private:
 
 struct SearchPciSlotResNew {
     static constexpr size_t MAXBASEADDRESSES = 6;
-    const std::array<uint32_t, MAXBASEADDRESSES> leBaseAddresses;
-    const uint32_t leSize[MAXBASEADDRESSES];
-    const uint32_t leBusNumber;
-    const uint32_t leSlotNumber;
-    const uint16_t leBoardIrq;
-    const uint16_t lePciRegViaPorts;
+    std::array<uint32_t, MAXBASEADDRESSES> leBaseAddresses;
+    uint32_t leSize[MAXBASEADDRESSES];
+    uint32_t leBusNumber;
+    uint32_t leSlotNumber;
+    uint16_t leBoardIrq;
+    uint16_t lePciRegViaPorts;
 };
 
 struct SearchPciBusResNew {
     static constexpr size_t MAXSLOTRESPONSE = 64;
-    uint32_t leFound;
-    std::array<SearchPciSlotResNew, MAXSLOTRESPONSE> slot;
+    uint32_t leFound {};
+    std::array<SearchPciSlotResNew, MAXSLOTRESPONSE> slot {};
     uint32_t nFound() const
     {
         return bhf::ads::letoh(leFound);
@@ -63,7 +63,7 @@ bool RouterAccess::PciScan(const uint64_t pci_id, std::ostream& os) const
 #define ROUTERADSGRP_ACCESS_HARDWARE 0x00000005
 #define ROUTERADSOFFS_A_HW_SEARCHPCIBUS 0x00000003
 
-    SearchPciBusResNew res {};
+    SearchPciBusResNew res;
     uint32_t bytesRead;
 
     const auto req = SearchPciBusReq {pci_id};
@@ -82,7 +82,7 @@ bool RouterAccess::PciScan(const uint64_t pci_id, std::ostream& os) const
 
     if (res.slot.size() < res.nFound()) {
         LOG_WARN(__FUNCTION__
-                 << "(): data seems corrupt. Slot count 0x" << std::hex << res.nFound() << " exceedes maximum 0x" << res.slot.size() <<
+                 << "(): data seems corrupt. Slot count 0x" << std::hex << res.nFound() << " exceeds maximum 0x" << res.slot.size() <<
                  " -> truncating\n");
     }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   )
   add_definitions(-D_GNU_SOURCE)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  # Compiler flags and definitions for Visual Studio come here
+  add_compile_options("/wd4244") # argument - integer data loss conversion warnings 
+  add_compile_options("/wd4267") # initializing - integer data loss conversion warnings
+  add_compile_options("/wd4996") # unsecure stdc api warnings
 endif()
 
 if (WIN32)
@@ -29,7 +31,10 @@ endif()
 option(ADSLIB_ONLY "Build only the ADS library, not examples or tests" OFF)
 
 add_subdirectory(AdsLib)
-if(ADSLIB_ONLY STREQUAL "OFF")
+
+if(${ADSLIB_ONLY} STREQUAL "OFF")
+    message(NOTICE "ADS: Not building tests and examples")
+else()
     add_subdirectory(AdsLibTest)
     add_subdirectory(example)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,17 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # Compiler flags and definitions for Visual Studio come here
 endif()
 
-option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+if (WIN32)
+  # need __dllexport/_dllimport declarations on classes & free functions Windows, so default to static linking
+  option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+else()
+  option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+endif()
+
+option(ADSLIB_ONLY "Build only the ADS library, not examples or tests" OFF)
 
 add_subdirectory(AdsLib)
-add_subdirectory(AdsLibTest)
-add_subdirectory(example)
+if(ADSLIB_ONLY STREQUAL "OFF")
+    add_subdirectory(AdsLibTest)
+    add_subdirectory(example)
+endif()


### PR DESCRIPTION
Some more Windows tweaks here, so we can use the same lib in our app both from Windows using TwinCAT ADS router and from Linux (and TCBSD in the future), without TwinCAT Router.

Also got some weird const-related compile errors when building RouterAccess, easily fixed.
We build in C++17 mode (both gcc and msvc), maybe that's what's different?