### PR TITLE
cmake: Install library and AdsTool

### DIFF
--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -10,6 +10,11 @@ set(SOURCES
   RTimeAccess.cpp
   Sockets.cpp
 
+  RegistryAccess.cpp
+  SymbolAccess.cpp
+
+  bhf/ParameterList.cpp
+
   standalone/AdsLib.cpp
   standalone/AmsConnection.cpp
   standalone/AmsNetId.cpp
@@ -19,8 +24,10 @@ set(SOURCES
 )
 
 add_library(ads ${SOURCES})
+add_library(ads::ads ALIAS ads)
 
-target_include_directories(ads PUBLIC .)
+target_include_directories(ads PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+$<INSTALL_INTERFACE:include/ads>)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   target_link_libraries(ads PUBLIC wsock32)

--- a/AdsTool/CMakeLists.txt
+++ b/AdsTool/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(AdsTool main.cpp)
+target_link_libraries(AdsTool PUBLIC ads::ads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,5 +23,54 @@ add_definitions(-DCONFIG_DEFAULT_LOGLEVEL=1)
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
 add_subdirectory(AdsLib)
+add_subdirectory(AdsTool)
 add_subdirectory(AdsLibTest)
 add_subdirectory(example)
+
+
+# Install library
+include(GenerateExportHeader)
+set(ADSLIB_VERSION 0.0.20)
+
+set_property(TARGET ads PROPERTY VERSION ${ADSLIB_VERSION})
+set_property(TARGET ads PROPERTY SOVERSION 3)
+
+
+# export library (either static or shared depending on BUILD_SHARED_LIBS)
+install(TARGETS ads AdsTool
+  EXPORT adsTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+  )
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/AdsLib/ DESTINATION include/ads/
+  FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h")
+
+
+set(cmake_configfile_install lib/cmake/ads)
+set(target_install_dest_name "${cmake_configfile_install}/adsTargets.cmake")
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/adsConfigVersion.cmake"
+  VERSION ${ADSLIB_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in"
+                "${CMAKE_CURRENT_BINARY_DIR}/cmake/adsConfig.cmake"
+                INSTALL_DESTINATION "${cmake_configfile_install}"
+                PATH_VARS target_install_dest_name)
+
+install(EXPORT adsTargets
+    FILE adsTargets.cmake
+    NAMESPACE ads::
+    DESTINATION "${cmake_configfile_install}"
+    EXPORT_LINK_INTERFACE_LIBRARIES)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/adsConfig.cmake"
+      "${CMAKE_CURRENT_BINARY_DIR}/adsConfigVersion.cmake"
+    DESTINATION "${cmake_configfile_install}")
+

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include ("@PACKAGE_target_install_dest_name@")


### PR DESCRIPTION
Added `install` to the cmake, so it can be used and found in other projects.


```
find_package(Threads REQUIRED)
find_package(ads REQUIRED)

add_executable(myAdsApp myAdsApp.cpp)
target_link_libraries(myAdsApp ads::ads)
```