### PR TITLE
Installing targets from subdirectories requires CMake 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.13.0)
 
 project(ads)
 


### PR DESCRIPTION
fixes #207 