### PR TITLE
fix: Do not hold global lock during connect

### DIFF
--- a/AdsLib/AmsRouter.h
+++ b/AdsLib/AmsRouter.h
@@ -6,6 +6,8 @@
 #pragma once
 
 #include "AmsConnection.h"
+#include <condition_variable>
+#include <mutex>
 #include <unordered_set>
 
 struct AmsRouter : Router {
@@ -30,10 +32,13 @@ struct AmsRouter : Router {
 private:
     AmsNetId localAddr;
     std::recursive_mutex mutex;
+    std::condition_variable_any connection_attempt_events;
+    std::map<AmsNetId, std::tuple<>> connection_attempts;
     std::unordered_set<std::unique_ptr<AmsConnection> > connections;
     std::map<AmsNetId, AmsConnection*> mapping;
 
     void DeleteIfLastConnection(const AmsConnection* conn);
+    void AwaitConnectionAttempts(const AmsNetId& ams, std::unique_lock<std::recursive_mutex>& lock);
 
     std::array<AmsPort, NUM_PORTS_MAX> ports;
 };


### PR DESCRIPTION
In the current implementation `AmsRouter::AddRoute` performs a `connect()` call holding the global lock https://github.com/Beckhoff/ADS/blob/0499e45c49e530133ee8386eabbed1da9eebaf18/AdsLib/standalone/AmsRouter.cpp#L54. This blocks all operations on all routes until the connection attempt finishes, this can be undesirable if the connect call takes a long time to complete (for example if a timeout occurs), causing issue #208.

This PR implements a more fine-grained locking approach that allows operations on different routes to be performed concurrently, operations on the same route should behave in the same way as the current version.

Closes #208 