### PR TITLE
standalone/AmsRouter::AddRoute(): preserve exception type

### DIFF
--- a/AdsLib/standalone/AmsRouter.cpp
+++ b/AdsLib/standalone/AmsRouter.cpp
@@ -79,7 +79,7 @@ long AmsRouter::AddRoute(AmsNetId ams, const std::string& host)
         lock.lock();
         connection_attempts.erase(ams);
         connection_attempt_events.notify_all();
-        throw e;
+        throw;
     }
 }
 


### PR DESCRIPTION
... such that AddLocalRoute() can really catch it.