### PR TITLE
Synthetic notifications

### DIFF
--- a/AdsLib/AdsLib.h
+++ b/AdsLib/AdsLib.h
@@ -129,6 +129,35 @@ long AdsSyncDelDeviceNotificationReqEx(long port, const AmsAddr *pAddr,
 				       uint32_t hNotification);
 
 /**
+ * A specific type of notification about the internal state of the library.
+ * When a state change as defined by nType parameter occurs the callback function is invoked
+ * @param[in] port port number of an Ads port that had previously been opened with AdsPortOpenEx().
+ * @param[in] pAddr Structure with NetId and port number of the ADS server.
+ * @param[in] nType The notification type.
+ * @param[in] pFunc Pointer to the structure describing the callback function.
+ * @param[in] hUser 32-bit value that is passed to the callback function.
+ * @param[out] pNotification Address of the variable that will receive the handle of the notification.
+ * @return [ADS Return
+ * Code](https://infosys.beckhoff.com/content/1031/tcadscommon/html/ads_returncodes.htm?id=1666172286265530469)
+ */
+long AdsAddSyntheticDeviceNotificationReqEx(long port, const AmsAddr *pAddr,
+				       uint32_t nType,
+				       PAdsSyntheticNotificationFuncEx pFunc,
+				       uint32_t hUser,
+				       uint32_t *pNotification);
+
+/**
+ * A notification defined previously is deleted from an ADS server.
+ * @param[in] port port number of an Ads port that had previously been opened with AdsPortOpenEx().
+ * @param[in] pAddr Structure with NetId and port number of the ADS server.
+ * @param[in] hNotification Address of the variable that contains the handle of the notification.
+ * @return [ADS Return
+ * Code](https://infosys.beckhoff.com/content/1031/tcadscommon/html/ads_returncodes.htm?id=1666172286265530469)
+ */
+long AdsDelSyntheticDeviceNotificationReqEx(long port, const AmsAddr *pAddr,
+				       uint32_t hNotification);
+
+/**
  * Read the configured timeout for the ADS functions. The standard value is 5000 ms.
  * @param[in] port port number of an Ads port that had previously been opened with AdsPortOpenEx().
  * @param[out] timeout Buffer to store timeout value in ms.

--- a/AdsLib/AdsSyntheticNotification.h
+++ b/AdsLib/AdsSyntheticNotification.h
@@ -6,36 +6,33 @@
 
 using VirtualConnection = std::pair<uint16_t, AmsAddr>;
 
-struct SyntheticNotification
-{
-    const VirtualConnection connection;
-    const uint32_t type;
+struct SyntheticNotification {
+	const VirtualConnection connection;
+	const uint32_t type;
 
-    SyntheticNotification(PAdsSyntheticNotificationFuncEx __func,
-                          uint32_t                        __hUser,
-                          AmsAddr                         __amsAddr,
-                          uint16_t                        __port,
-                          uint32_t                        __type)
-        : connection({ __port, __amsAddr }),
-        type(__type),
-        callback(__func),
-        hNotification(0),
-        hUser(__hUser)
-    {
-    }
+	SyntheticNotification(PAdsSyntheticNotificationFuncEx __func,
+			      uint32_t __hUser, AmsAddr __amsAddr,
+			      uint16_t __port, uint32_t __type)
+		: connection({ __port, __amsAddr })
+		, type(__type)
+		, callback(__func)
+		, hNotification(0)
+		, hUser(__hUser)
+	{
+	}
 
-    void Notify()
-    {
-        callback(&connection.second, hNotification, hUser);
-    }
+	void Notify()
+	{
+		callback(&connection.second, hNotification, hUser);
+	}
 
-    void hNotify(uint32_t value)
-    {
-        hNotification = value;
-    }
+	void hNotify(uint32_t value)
+	{
+		hNotification = value;
+	}
 
-private:
-    const PAdsSyntheticNotificationFuncEx callback;
-    uint32_t hNotification;
-    const uint32_t hUser;
+    private:
+	const PAdsSyntheticNotificationFuncEx callback;
+	uint32_t hNotification;
+	const uint32_t hUser;
 };

--- a/AdsLib/AdsSyntheticNotification.h
+++ b/AdsLib/AdsSyntheticNotification.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "AdsDef.h"
+
+using VirtualConnection = std::pair<uint16_t, AmsAddr>;
+
+struct SyntheticNotification
+{
+    const VirtualConnection connection;
+    const uint32_t type;
+
+    SyntheticNotification(PAdsSyntheticNotificationFuncEx __func,
+                          uint32_t                        __hUser,
+                          AmsAddr                         __amsAddr,
+                          uint16_t                        __port,
+                          uint32_t                        __type)
+        : connection({ __port, __amsAddr }),
+        type(__type),
+        callback(__func),
+        hNotification(0),
+        hUser(__hUser)
+    {
+    }
+
+    void Notify()
+    {
+        callback(&connection.second, hNotification, hUser);
+    }
+
+    void hNotify(uint32_t value)
+    {
+        hNotification = value;
+    }
+
+private:
+    const PAdsSyntheticNotificationFuncEx callback;
+    uint32_t hNotification;
+    const uint32_t hUser;
+};

--- a/AdsLib/AmsConnection.h
+++ b/AdsLib/AmsConnection.h
@@ -74,6 +74,9 @@ struct AmsConnection {
 	SharedDispatcher
 	CreateNotifyMapping(uint32_t hNotify,
 			    std::shared_ptr<Notification> notification);
+	SharedDispatcher
+	CreateSyntheticNotifyMapping(uint32_t hNotify,
+			    std::shared_ptr<SyntheticNotification> notification);
 	long DeleteNotification(const AmsAddr &amsAddr, uint32_t hNotify,
 				uint32_t tmms, uint16_t port);
 	long AdsRequest(AmsRequest &request, uint32_t timeout);

--- a/AdsLib/AmsPort.h
+++ b/AdsLib/AmsPort.h
@@ -19,9 +19,14 @@ struct AmsPort {
 			     SharedDispatcher dispatcher);
 	long DelNotification(AmsAddr ams, uint32_t hNotify);
 
+	void AddSyntheticNotification(AmsAddr ams, uint32_t hNotify,
+			     SharedDispatcher dispatcher);
+	long DelSyntheticNotification(AmsAddr ams, uint32_t hNotify);
+
     private:
 	using NotifyUUID = std::pair<const AmsAddr, const uint32_t>;
 	static const uint32_t DEFAULT_TIMEOUT = 5000;
 	std::map<NotifyUUID, SharedDispatcher> dispatcherList;
+	std::map<NotifyUUID, SharedDispatcher> syntheticDispatcherList;
 	std::mutex mutex;
 };

--- a/AdsLib/AmsRouter.h
+++ b/AdsLib/AmsRouter.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "AmsConnection.h"
+#include <atomic>
 #include <unordered_set>
 
 struct AmsRouter : Router {
@@ -21,6 +22,11 @@ struct AmsRouter : Router {
 			     std::shared_ptr<Notification> notify);
 	long DelNotification(uint16_t port, const AmsAddr *pAddr,
 			     uint32_t hNotification);
+	long AddSyntheticNotification(uint16_t port, const AmsAddr &addr, uint32_t *pNotification,
+			     std::shared_ptr<SyntheticNotification> notify);
+	long DelSyntheticNotification(uint16_t port, const AmsAddr *pAddr,
+			     uint32_t hNotification);
+	uint32_t AllocateNotifyId();
 
 	[[deprecated]]
 	long AddRoute(AmsNetId ams, const IpV4 &ip);
@@ -43,4 +49,6 @@ struct AmsRouter : Router {
 	void DeleteIfLastConnection(const AmsConnection *conn);
 
 	std::array<AmsPort, NUM_PORTS_MAX> ports;
+
+	std::atomic<uint32_t> nextNotifyId;
 };

--- a/AdsLib/NotificationDispatcher.h
+++ b/AdsLib/NotificationDispatcher.h
@@ -13,7 +13,6 @@
 #include <atomic>
 #include <functional>
 #include <map>
-#include <set>
 #include <thread>
 #include <vector>
 
@@ -21,7 +20,8 @@ using DeleteNotificationCallback =
 	std::function<long(uint32_t hNotify, uint32_t tmms)>;
 
 struct NotificationDispatcher {
-	NotificationDispatcher(DeleteNotificationCallback callback);
+	NotificationDispatcher(VirtualConnection connection,
+		     DeleteNotificationCallback callback);
 	~NotificationDispatcher();
 	void Emplace(uint32_t hNotify,
 		     std::shared_ptr<Notification> notification);
@@ -35,16 +35,17 @@ struct NotificationDispatcher {
 	const DeleteNotificationCallback deleteNotification;
 	RingBuffer ring;
 
-    private:
+	private:
+	const VirtualConnection connection;
 	std::map<uint32_t, std::shared_ptr<Notification> > notifications;
-	std::map<uint32_t, std::shared_ptr<SyntheticNotification> > syntheticNotifications;
+	std::map<uint32_t, std::shared_ptr<SyntheticNotification> >	syntheticNotifications;
 	std::recursive_mutex mutex;
 	Semaphore sem;
 	std::atomic<bool> stopExecution;
 	std::thread thread;
 
 	std::shared_ptr<Notification> Find(uint32_t hNotify);
-	std::vector<std::shared_ptr<SyntheticNotification>> FindSynthetic(
-		const std::set<VirtualConnection>& connections, uint32_t type);
+	std::vector<std::shared_ptr<SyntheticNotification> >
+	FindSynthetic(uint32_t type);
 };
 using SharedDispatcher = std::shared_ptr<NotificationDispatcher>;

--- a/AdsLib/NotificationDispatcher.h
+++ b/AdsLib/NotificationDispatcher.h
@@ -6,13 +6,16 @@
 #pragma once
 
 #include "AdsNotification.h"
+#include "AdsSyntheticNotification.h"
 #include "AmsHeader.h"
 #include "Semaphore.h"
 
 #include <atomic>
 #include <functional>
 #include <map>
+#include <set>
 #include <thread>
+#include <vector>
 
 using DeleteNotificationCallback =
 	std::function<long(uint32_t hNotify, uint32_t tmms)>;
@@ -23,6 +26,9 @@ struct NotificationDispatcher {
 	void Emplace(uint32_t hNotify,
 		     std::shared_ptr<Notification> notification);
 	long Erase(uint32_t hNotify, uint32_t tmms);
+	void EmplaceSynthetic(uint32_t hNotify,
+		     std::shared_ptr<SyntheticNotification> notification);
+	long EraseSynthetic(uint32_t hNotify);
 	void Notify();
 	void Run();
 
@@ -31,11 +37,14 @@ struct NotificationDispatcher {
 
     private:
 	std::map<uint32_t, std::shared_ptr<Notification> > notifications;
+	std::map<uint32_t, std::shared_ptr<SyntheticNotification> > syntheticNotifications;
 	std::recursive_mutex mutex;
 	Semaphore sem;
 	std::atomic<bool> stopExecution;
 	std::thread thread;
 
 	std::shared_ptr<Notification> Find(uint32_t hNotify);
+	std::vector<std::shared_ptr<SyntheticNotification>> FindSynthetic(
+		const std::set<VirtualConnection>& connections, uint32_t type);
 };
 using SharedDispatcher = std::shared_ptr<NotificationDispatcher>;

--- a/AdsLib/RingBuffer.h
+++ b/AdsLib/RingBuffer.h
@@ -10,6 +10,8 @@
 #include <memory>
 
 struct RingBuffer {
+	friend struct RingBufferTransaction;
+
 	RingBuffer(size_t N)
 		: dataSize(N + 1)
 		, data(new uint8_t[N + 1])

--- a/AdsLib/RingBufferTransaction.h
+++ b/AdsLib/RingBufferTransaction.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "RingBuffer.h"
+
+#include <cassert>
+#include <cstdint>
+
+struct RingBufferTransaction {
+	RingBufferTransaction(RingBuffer &target)
+		: buffer(target)
+		, write(target.write)
+	{
+	}
+
+	size_t BytesFree() const
+	{
+		return (write < buffer.read) ?
+			       buffer.read - write - 1 :
+			       buffer.dataSize - 1 - (write - buffer.read);
+	}
+
+	size_t WriteChunk() const
+	{
+		return (write < buffer.read) ?
+			       buffer.read - write - 1 :
+			       buffer.data.get() + buffer.dataSize - write -
+				       (buffer.data.get() == buffer.read);
+	}
+
+	void Write(size_t n)
+	{
+		assert(n <= BytesFree());
+		write = buffer.Increment(write, n);
+	}
+
+	void Commit()
+	{
+		buffer.write = write;
+	}
+
+	RingBuffer &buffer;
+	uint8_t *write;
+};

--- a/AdsLib/standalone/AdsDef.h
+++ b/AdsLib/standalone/AdsDef.h
@@ -279,6 +279,11 @@ enum AMSPORT : uint16_t {
 #define ADSERR_CLIENT_SYNCPORTLOCKED \
 	(0x55 + ERR_ADSERRS) /**< sync port is locked */
 
+////////////////////////////////////////////////////////////////////////////////
+// Synthetic notification types
+#define NOTIFY_NOTIFICATION_RCV 0x02 /**< notification received notification */
+#define NOTIFY_CONNECTION_LOST 0x01 /**< connection lost notification */
+
 #pragma pack(push, 1)
 
 /**
@@ -425,6 +430,16 @@ struct AdsNotificationHeader {
  */
 typedef void (*PAdsNotificationFuncEx)(
 	const AmsAddr *pAddr, const AdsNotificationHeader *pNotification,
+	uint32_t hUser);
+
+/**
+ * @brief Type definition of the callback function required by the AdsSyncAddSyntheticDeviceNotificationReqEx() function.
+ * @param[in] pAddr Structure with NetId and port number of the ADS server.
+ * @param[in] hNotification Handle for the notification. Is specified when the notification is defined.
+ * @param[in] hUser custom handle pass to AdsSyncAddSyntheticDeviceNotificationReqEx() during registration
+ */
+typedef void (*PAdsSyntheticNotificationFuncEx)(
+	const AmsAddr *pAddr, uint32_t hNotification,
 	uint32_t hUser);
 
 #define ADSSYMBOLFLAG_PERSISTENT ((uint32_t)(1 << 0))

--- a/AdsLib/standalone/AdsLib.cpp
+++ b/AdsLib/standalone/AdsLib.cpp
@@ -272,6 +272,39 @@ long AdsSyncDelDeviceNotificationReqEx(long port, const AmsAddr *pAddr,
 					   hNotification);
 }
 
+long AdsAddSyntheticDeviceNotificationReqEx(long port, const AmsAddr *pAddr,
+				       uint32_t nType,
+				       PAdsSyntheticNotificationFuncEx pFunc,
+				       uint32_t hUser, uint32_t *pNotification)
+{
+	ASSERT_PORT_AND_AMSADDR(port, pAddr);
+	if (!pFunc || !pNotification) {
+		return ADSERR_CLIENT_INVALIDPARM;
+	}
+
+	if (nType != NOTIFY_NOTIFICATION_RCV) {
+		return ADSERR_CLIENT_INVALIDPARM;
+	}
+	// TODO: Add NOTIFY_CONNECTION_LOST
+
+	try {
+		auto notify = std::make_shared<SyntheticNotification>(
+			pFunc, hUser, *pAddr, (uint16_t)port, nType);
+		return GetRouter().AddSyntheticNotification(
+			(uint16_t)port, *pAddr, pNotification, notify);
+	} catch (const std::bad_alloc &) {
+		return GLOBALERR_NO_MEMORY;
+	}
+}
+
+long AdsDelSyntheticDeviceNotificationReqEx(long port, const AmsAddr *pAddr,
+				       uint32_t hNotification)
+{
+	ASSERT_PORT_AND_AMSADDR(port, pAddr);	
+	return GetRouter().DelSyntheticNotification((uint16_t)port, pAddr,
+						    hNotification);
+}
+
 long AdsSyncGetTimeoutEx(long port, uint32_t *timeout)
 {
 	ASSERT_PORT(port);

--- a/AdsLib/standalone/AdsLib.cpp
+++ b/AdsLib/standalone/AdsLib.cpp
@@ -282,10 +282,10 @@ long AdsAddSyntheticDeviceNotificationReqEx(long port, const AmsAddr *pAddr,
 		return ADSERR_CLIENT_INVALIDPARM;
 	}
 
-	if (nType != NOTIFY_NOTIFICATION_RCV) {
+	if (nType != NOTIFY_NOTIFICATION_RCV &&
+	    nType != NOTIFY_CONNECTION_LOST) {
 		return ADSERR_CLIENT_INVALIDPARM;
 	}
-	// TODO: Add NOTIFY_CONNECTION_LOST
 
 	try {
 		auto notify = std::make_shared<SyntheticNotification>(
@@ -300,7 +300,7 @@ long AdsAddSyntheticDeviceNotificationReqEx(long port, const AmsAddr *pAddr,
 long AdsDelSyntheticDeviceNotificationReqEx(long port, const AmsAddr *pAddr,
 				       uint32_t hNotification)
 {
-	ASSERT_PORT_AND_AMSADDR(port, pAddr);	
+	ASSERT_PORT_AND_AMSADDR(port, pAddr);
 	return GetRouter().DelSyntheticNotification((uint16_t)port, pAddr,
 						    hNotification);
 }

--- a/AdsLib/standalone/AmsConnection.cpp
+++ b/AdsLib/standalone/AmsConnection.cpp
@@ -93,6 +93,16 @@ AmsConnection::CreateNotifyMapping(uint32_t hNotify,
 	return dispatcher;
 }
 
+SharedDispatcher
+AmsConnection::CreateSyntheticNotifyMapping(uint32_t hNotify,
+				   std::shared_ptr<SyntheticNotification> notification)
+{
+	auto dispatcher = DispatcherListAdd(notification->connection);
+	notification->hNotify(hNotify);
+	dispatcher->EmplaceSynthetic(hNotify, notification);
+	return dispatcher;
+}
+
 long AmsConnection::DeleteNotification(const AmsAddr &amsAddr, uint32_t hNotify,
 				       uint32_t tmms, uint16_t port)
 {

--- a/AdsLib/standalone/AmsConnection.cpp
+++ b/AdsLib/standalone/AmsConnection.cpp
@@ -47,10 +47,13 @@ AmsConnection::DispatcherListAdd(const VirtualConnection &connection)
 	std::lock_guard<std::recursive_mutex> lock(dispatcherListMutex);
 	return dispatcherList
 		.emplace(connection,
-			 std::make_shared<NotificationDispatcher>(std::bind(
-				 &AmsConnection::DeleteNotification, this,
-				 connection.second, std::placeholders::_1,
-				 std::placeholders::_2, connection.first)))
+			 std::make_shared<NotificationDispatcher>(
+				 connection,
+				 std::bind(&AmsConnection::DeleteNotification,
+					   this, connection.second,
+					   std::placeholders::_1,
+					   std::placeholders::_2,
+					   connection.first)))
 		.first->second;
 }
 

--- a/AdsLib/standalone/AmsConnection.cpp
+++ b/AdsLib/standalone/AmsConnection.cpp
@@ -5,6 +5,7 @@
 
 #include "AmsConnection.h"
 #include "Log.h"
+#include "RingBufferTransaction.h"
 
 AmsResponse::AmsResponse()
 	: request(nullptr)
@@ -304,7 +305,7 @@ bool AmsConnection::ReceiveNotification(const AoEHeader &header)
 		return false;
 	}
 
-	auto &ring = dispatcher->ring;
+	auto ring = RingBufferTransaction(dispatcher->ring);
 	auto bytesLeft = header.length();
 	if (bytesLeft + sizeof(bytesLeft) > ring.BytesFree()) {
 		ReceiveJunk(bytesLeft);
@@ -329,6 +330,8 @@ bool AmsConnection::ReceiveNotification(const AoEHeader &header)
 	}
 	Receive(ring.write, bytesLeft);
 	ring.Write(bytesLeft);
+
+	ring.Commit();
 	dispatcher->Notify();
 	return true;
 }
@@ -338,6 +341,9 @@ void AmsConnection::TryRecv()
 	try {
 		Recv();
 	} catch (const std::runtime_error &e) {
+		for (auto &dispatcher : dispatcherList) {
+			dispatcher.second->Notify();
+		}
 		LOG_INFO(e.what());
 	}
 }

--- a/AdsLib/standalone/AmsPort.cpp
+++ b/AdsLib/standalone/AmsPort.cpp
@@ -26,6 +26,13 @@ void AmsPort::AddNotification(const AmsAddr ams, const uint32_t hNotify,
 	dispatcherList.emplace(NotifyUUID{ ams, hNotify }, dispatcher);
 }
 
+void AmsPort::AddSyntheticNotification(const AmsAddr ams, const uint32_t hNotify,
+			      SharedDispatcher dispatcher)
+{
+	std::lock_guard<std::mutex> lock(mutex);
+	syntheticDispatcherList.emplace(NotifyUUID { ams, hNotify }, dispatcher);
+}
+
 void AmsPort::Close()
 {
 	std::lock_guard<std::mutex> lock(mutex);
@@ -34,6 +41,12 @@ void AmsPort::Close()
 		d.second->Erase(d.first.second, tmms);
 	}
 	dispatcherList.clear();
+
+	for (auto &d : syntheticDispatcherList) {
+		d.second->EraseSynthetic(d.first.second);
+	}
+	syntheticDispatcherList.clear();
+
 	tmms = DEFAULT_TIMEOUT;
 	port = 0;
 }
@@ -45,6 +58,18 @@ long AmsPort::DelNotification(const AmsAddr ams, uint32_t hNotify)
 	if (it != dispatcherList.end()) {
 		const auto status = it->second->Erase(hNotify, tmms);
 		dispatcherList.erase(it);
+		return status;
+	}
+	return ADSERR_CLIENT_REMOVEHASH;
+}
+
+long AmsPort::DelSyntheticNotification(AmsAddr ams, uint32_t hNotify)
+{
+	std::lock_guard<std::mutex> lock(mutex);
+	auto it = syntheticDispatcherList.find({ ams, hNotify });
+	if (it != syntheticDispatcherList.end()) {
+		const auto status = it->second->EraseSynthetic(hNotify);
+		syntheticDispatcherList.erase(it);
 		return status;
 	}
 	return ADSERR_CLIENT_REMOVEHASH;

--- a/AdsLib/standalone/AmsRouter.cpp
+++ b/AdsLib/standalone/AmsRouter.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 
 AmsRouter::AmsRouter(AmsNetId netId)
-	: localAddr(netId)
+	: localAddr(netId), nextNotifyId(1)
 {
 }
 
@@ -236,11 +236,39 @@ long AmsRouter::AddNotification(AmsRequest &request, uint32_t *pNotification,
 	return status;
 }
 
+long AmsRouter::AddSyntheticNotification(uint16_t port, const AmsAddr &addr, uint32_t *pNotification,
+				std::shared_ptr<SyntheticNotification> notify)
+{
+	auto ads = GetConnection(addr.netId);
+	if (!ads) {
+		return GLOBALERR_MISSING_ROUTE;
+	}
+
+	*pNotification = AllocateNotifyId();
+	auto dispatcher = ads->CreateSyntheticNotifyMapping(*pNotification, notify);
+	auto& amsPort = ports[port - Router::PORT_BASE];
+	amsPort.AddSyntheticNotification(addr, *pNotification, dispatcher);
+
+	return 0;
+}
+
 long AmsRouter::DelNotification(uint16_t port, const AmsAddr *pAddr,
 				uint32_t hNotification)
 {
 	auto &p = ports[port - Router::PORT_BASE];
 	return p.DelNotification(*pAddr, hNotification);
+}
+
+long AmsRouter::DelSyntheticNotification(uint16_t port, const AmsAddr *pAddr,
+				uint32_t hNotification)
+{
+	auto &p = ports[port - Router::PORT_BASE];
+	return p.DelSyntheticNotification(*pAddr, hNotification);
+}
+
+uint32_t AmsRouter::AllocateNotifyId()
+{
+	return nextNotifyId.fetch_add(1, std::memory_order_acq_rel);
 }
 
 void AmsRouter::AwaitConnectionAttempts(

--- a/AdsLib/standalone/NotificationDispatcher.cpp
+++ b/AdsLib/standalone/NotificationDispatcher.cpp
@@ -90,6 +90,13 @@ void NotificationDispatcher::Run()
 		if (stopExecution) {
 			return;
 		}
+		if (ring.BytesAvailable() == 0) {
+			for (auto &notification : FindSynthetic(NOTIFY_CONNECTION_LOST)) {
+				notification->Notify();
+			}
+			continue;
+		}
+
 		auto fullLength = ring.ReadFromLittleEndian<uint32_t>();
 		const auto length = ring.ReadFromLittleEndian<uint32_t>();
 		(void)length;

--- a/AdsLib/standalone/NotificationDispatcher.cpp
+++ b/AdsLib/standalone/NotificationDispatcher.cpp
@@ -6,12 +6,12 @@
 #include "NotificationDispatcher.h"
 #include "Log.h"
 #include <future>
-#include <set>
 
 NotificationDispatcher::NotificationDispatcher(
-	DeleteNotificationCallback callback)
+	VirtualConnection connection, DeleteNotificationCallback callback)
 	: deleteNotification(callback)
 	, ring(4 * 1024 * 1024)
+	, connection(connection)
 	, stopExecution(false)
 	, thread(&NotificationDispatcher::Run, this)
 {
@@ -63,13 +63,14 @@ std::shared_ptr<Notification> NotificationDispatcher::Find(uint32_t hNotify)
 	return {};
 }
 
-std::vector<std::shared_ptr<SyntheticNotification>> NotificationDispatcher::FindSynthetic(const std::set<VirtualConnection>& connections, uint32_t type)
+std::vector<std::shared_ptr<SyntheticNotification> >
+NotificationDispatcher::FindSynthetic(uint32_t type)
 {
-	std::vector<std::shared_ptr<SyntheticNotification>> found;
+	std::vector<std::shared_ptr<SyntheticNotification> > found;
 
 	std::lock_guard<std::recursive_mutex> lock(mutex);
-	for (auto& notification : syntheticNotifications) {
-		if (notification.second->type == type && connections.find(notification.second->connection) != connections.end()) {
+	for (auto &notification : syntheticNotifications) {
+		if (notification.second->type == type) {
 			found.push_back(notification.second);
 		}
 	}
@@ -84,8 +85,6 @@ void NotificationDispatcher::Notify()
 
 void NotificationDispatcher::Run()
 {
-	std::set<VirtualConnection> notifiedConnections;
-
 	for (;;) {
 		sem.acquire();
 		if (stopExecution) {
@@ -120,7 +119,6 @@ void NotificationDispatcher::Run()
 						goto cleanup;
 					}
 					notification->Notify(timestamp, ring);
-					notifiedConnections.emplace(notification->connection);
 				} else {
 					ring.Read(size);
 				}
@@ -130,7 +128,7 @@ void NotificationDispatcher::Run()
 cleanup:
 		ring.Read(fullLength);
 
-		for (auto& notification : FindSynthetic(notifiedConnections, NOTIFY_NOTIFICATION_RCV)) {
+		for (auto &notification : FindSynthetic(NOTIFY_NOTIFICATION_RCV)) {
 			notification->Notify();
 		}
 	}

--- a/AdsLib/standalone/NotificationDispatcher.cpp
+++ b/AdsLib/standalone/NotificationDispatcher.cpp
@@ -6,6 +6,7 @@
 #include "NotificationDispatcher.h"
 #include "Log.h"
 #include <future>
+#include <set>
 
 NotificationDispatcher::NotificationDispatcher(
 	DeleteNotificationCallback callback)
@@ -30,12 +31,26 @@ void NotificationDispatcher::Emplace(uint32_t hNotify,
 	notifications.emplace(hNotify, notification);
 }
 
+void NotificationDispatcher::EmplaceSynthetic(uint32_t hNotify,
+				     std::shared_ptr<SyntheticNotification> notification)
+{
+	std::lock_guard<std::recursive_mutex> lock(mutex);
+	syntheticNotifications.emplace(hNotify, notification);
+}
+
 long NotificationDispatcher::Erase(uint32_t hNotify, uint32_t tmms)
 {
 	const auto status = deleteNotification(hNotify, tmms);
 	std::lock_guard<std::recursive_mutex> lock(mutex);
 	notifications.erase(hNotify);
 	return status;
+}
+
+long NotificationDispatcher::EraseSynthetic(uint32_t hNotify)
+{
+	std::lock_guard<std::recursive_mutex> lock(mutex);
+	notifications.erase(hNotify);
+	return ADSERR_NOERR;
 }
 
 std::shared_ptr<Notification> NotificationDispatcher::Find(uint32_t hNotify)
@@ -48,6 +63,20 @@ std::shared_ptr<Notification> NotificationDispatcher::Find(uint32_t hNotify)
 	return {};
 }
 
+std::vector<std::shared_ptr<SyntheticNotification>> NotificationDispatcher::FindSynthetic(const std::set<VirtualConnection>& connections, uint32_t type)
+{
+	std::vector<std::shared_ptr<SyntheticNotification>> found;
+
+	std::lock_guard<std::recursive_mutex> lock(mutex);
+	for (auto& notification : syntheticNotifications) {
+		if (notification.second->type == type && connections.find(notification.second->connection) != connections.end()) {
+			found.push_back(notification.second);
+		}
+	}
+
+	return found;
+}
+
 void NotificationDispatcher::Notify()
 {
 	sem.release();
@@ -55,6 +84,8 @@ void NotificationDispatcher::Notify()
 
 void NotificationDispatcher::Run()
 {
+	std::set<VirtualConnection> notifiedConnections;
+
 	for (;;) {
 		sem.acquire();
 		if (stopExecution) {
@@ -89,6 +120,7 @@ void NotificationDispatcher::Run()
 						goto cleanup;
 					}
 					notification->Notify(timestamp, ring);
+					notifiedConnections.emplace(notification->connection);
 				} else {
 					ring.Read(size);
 				}
@@ -97,5 +129,9 @@ void NotificationDispatcher::Run()
 		}
 cleanup:
 		ring.Read(fullLength);
+
+		for (auto& notification : FindSynthetic(notifiedConnections, NOTIFY_NOTIFICATION_RCV)) {
+			notification->Notify();
+		}
 	}
 }


### PR DESCRIPTION
**Overview**

This pull request introduces *synthetic notifications* as a new notification channel in the ADS library.
Unlike standard ADS notifications that originate from target ADS devices, synthetic notifications are generated within the library to inform users about key internal events and states.

**Implemented Synthetic Notifications**   
Two new synthetic notification types have been added:

1. NOTIFY_CONNECTION_LOST   
   This synthetic notification type is emitted when the connection to a target ADS device is lost.
   Previously, client code could only detect a connection failure indirectly by sending a request and receiving an error response. For applications that rely mainly on ADS notifications to track symbol updates (without performing regular read/write operations), this made it impossible to detect connection loss at runtime.   
   With *NOTIFY_CONNECTION_LOST*, the library now notifies registered users whenever any socket operation for a given connection fails, allowing client code to react immediately to connection issues.

2. NOTIFY_NOTIFICATION_RCV   
   This synthetic notification type is emitted whenever any ADS notification is received from a target device.  
   It serves as a lightweight, data-free event that is triggered after the invocation of all ADS notifications contained within an AMS packet, enabling client code to receive a general “summary” notification when any subscribed ADS symbol is updated.  
   This can be useful in scenarios where multiple symbols are updated via ADS notifications, and a single trigger is needed to perform follow-up actions, such as refreshing a GUI, aggregating data, or committing a database transaction.