### PR TITLE
Add shared library to build targets

### DIFF
--- a/AdsLib/.gitattributes
+++ b/AdsLib/.gitattributes
@@ -1,0 +1,2 @@
+*.h text eol=lf
+*.cpp text eol=lf

--- a/AdsLib/AdsLib.h
+++ b/AdsLib/AdsLib.h
@@ -188,9 +188,9 @@ long GetRemoteAddress(const std::string &remote, AmsNetId &netId);
 }
 }
 
-#define AdsAddRoute bhf::ads::AddLocalRoute
-#define AdsDelRoute bhf::ads::DelLocalRoute
-#define AdsSetLocalAddress bhf::ads::SetLocalAddress
+long AdsAddRoute(AmsNetId netId, const char* ipAddr);
+void AdsDelRoute(AmsNetId netId);
+void AdsSetLocalAddress(AmsNetId netId);
 
 #ifdef __cplusplus
 }

--- a/AdsLib/AdsLib.h
+++ b/AdsLib/AdsLib.h
@@ -13,6 +13,9 @@
 
 #include "Sockets.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * Reads data synchronously from an ADS server.
  * @param[in] port port number of an Ads port that had previously been opened with AdsPortOpenEx().
@@ -188,3 +191,7 @@ long GetRemoteAddress(const std::string &remote, AmsNetId &netId);
 #define AdsAddRoute bhf::ads::AddLocalRoute
 #define AdsDelRoute bhf::ads::DelLocalRoute
 #define AdsSetLocalAddress bhf::ads::SetLocalAddress
+
+#ifdef __cplusplus
+}
+#endif

--- a/AdsLib/standalone/AdsLib.cpp
+++ b/AdsLib/standalone/AdsLib.cpp
@@ -6,6 +6,7 @@
 #include "AdsLib.h"
 #include "AmsRouter.h"
 
+extern "C" {
 static AmsRouter &GetRouter()
 {
 	static AmsRouter router;
@@ -285,4 +286,5 @@ long AdsSyncSetTimeoutEx(long port, uint32_t timeout)
 {
 	ASSERT_PORT(port);
 	return GetRouter().SetTimeout((uint16_t)port, timeout);
+}
 }

--- a/AdsLib/standalone/AdsLib.cpp
+++ b/AdsLib/standalone/AdsLib.cpp
@@ -287,4 +287,16 @@ long AdsSyncSetTimeoutEx(long port, uint32_t timeout)
 	ASSERT_PORT(port);
 	return GetRouter().SetTimeout((uint16_t)port, timeout);
 }
+
+long AdsAddRoute(AmsNetId netId, const char* ipAddr) {
+	return bhf::ads::AddLocalRoute(netId, ipAddr);
+}
+
+void AdsDelRoute(AmsNetId netId) {
+	bhf::ads::DelLocalRoute(netId);
+}
+
+void AdsSetLocalAddress(AmsNetId netId) {
+	bhf::ads::SetLocalAddress(netId);
+}
 }

--- a/AdsLib/standalone/AdsLib.h
+++ b/AdsLib/standalone/AdsLib.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "AdsDef.h"
+#ifdef __cplusplus
 extern "C" {
+#endif
 /**
  * The connection (communication port) to the message router is
  * closed. The port to be closed must previously have been opened via
@@ -38,4 +40,6 @@ long AdsGetLocalAddressEx(long port, AmsAddr *pAddr);
  * @return [ADS Return Code](https://infosys.beckhoff.com/content/1031/tcadscommon/html/ads_returncodes.htm?id=1666172286265530469)
  */
 long AdsSyncSetTimeoutEx(long port, uint32_t timeout);
+#ifdef __cplusplus
 }
+#endif

--- a/AdsLib/standalone/AdsLib.h
+++ b/AdsLib/standalone/AdsLib.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "AdsDef.h"
-
+extern "C" {
 /**
  * The connection (communication port) to the message router is
  * closed. The port to be closed must previously have been opened via
@@ -38,3 +38,4 @@ long AdsGetLocalAddressEx(long port, AmsAddr *pAddr);
  * @return [ADS Return Code](https://infosys.beckhoff.com/content/1031/tcadscommon/html/ads_returncodes.htm?id=1666172286265530469)
  */
 long AdsSyncSetTimeoutEx(long port, uint32_t timeout);
+}

--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,15 @@ adslib = static_library('AdsLib',
   install: true,
 )
 
+adslib_so = shared_library('adslib',
+  [common_files, router_files],
+  include_directories: inc,
+  install: true,
+  name_prefix: '',
+  name_suffix: 'so',
+  dependencies: [dependency('threads')],
+)
+
 install_libs = [ adslib ]
 
 adslib_dep = declare_dependency(


### PR DESCRIPTION
This PR resolves #284 by adding a shared library to the build targets. The compiled adslib.so is used by pyads, a thin Python wrapper for ADS.

The PR contains these changes:
- set .gitattributes to set eol character to LF
- add extern "C" statement to prevent name mangling. This is needed to access the functions by their proper names in the shared library.
- Add a new build target to meson: adslib.so 
