### PR TITLE
Create subfolder for headers, standardize .so output name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -107,7 +107,7 @@ adslib = static_library('AdsLib',
   install: true,
 )
 
-adslib_so = shared_library('adslib',
+adslib_so = shared_library('AdsLib',
   [common_files, router_files],
   cpp_args: [
     '-DBHF_ADS_EXPORT_C',

--- a/meson.build
+++ b/meson.build
@@ -66,17 +66,29 @@ install_headers(
   'AdsLib/Semaphore.h',
   'AdsLib/Sockets.h',
   'AdsLib/SymbolAccess.h',
-  'AdsLib/TwinCAT/AdsDef.h',
-  'AdsLib/TwinCAT/AdsLib.h',
-  'AdsLib/bhf/ParameterList.h',
-  'AdsLib/bhf/StringToInteger.h',
-  'AdsLib/bhf/WindowsQuirks.h',
-  'AdsLib/standalone/AdsDef.h',
-  'AdsLib/standalone/AdsLib.h',
   'AdsLib/wrap_endian.h',
   'AdsLib/wrap_registry.h',
   'AdsLib/wrap_socket.h',
   subdir: 'AdsLib'
+)
+
+install_headers(
+  'AdsLib/bhf/ParameterList.h',
+  'AdsLib/bhf/StringToInteger.h',
+  'AdsLib/bhf/WindowsQuirks.h',
+  subdir: 'AdsLib/bhf'
+)
+
+install_headers(
+  'AdsLib/standalone/AdsDef.h',
+  'AdsLib/standalone/AdsLib.h',
+  subdir: 'AdsLib/standalone'
+)
+
+install_headers(
+  'AdsLib/TwinCAT/AdsDef.h',
+  'AdsLib/TwinCAT/AdsLib.h',
+  subdir: 'AdsLib/TwinCAT'
 )
 
 inc = include_directories([


### PR DESCRIPTION
- [fix: create subfolder for installed header files](https://github.com/Beckhoff/ADS/commit/c203b99d4400d8df187484fff5352049007e4b41) 

As of now, all header files are installed in a flat "AdsLib" folder. For
most files that is ok, but since some header files have the same name in
the internal folders, they get overwritten (e.g. AdsDef.h, AdsLib.h).
This commit creates a subfolder for the internal header files, keeping
the same folder structure as in the source code.

- [fix: rename .so output to use PascalCase](https://github.com/Beckhoff/ADS/commit/abb4e7d20878511502180e52b7a9c7e835fb44e4)
Closes #293 