### PR TITLE
Small fixes

### DIFF
--- a/AdsLib/AdsException.h
+++ b/AdsLib/AdsException.h
@@ -8,25 +8,13 @@
 #include <stdexcept>
 #include <string>
 
-struct AdsException : std::exception {
-	AdsException(const long adsErrorCode)
-		: errorCode(adsErrorCode)
-		, m_Message("Ads operation failed with error code " +
-			    std::to_string(adsErrorCode) + ".")
+struct AdsException : std::runtime_error {
+	explicit AdsException(const long adsErrorCode)
+		: std::runtime_error("Ads operation failed with error code " +
+		                     std::to_string(adsErrorCode) + "."),
+		  errorCode(adsErrorCode)
 	{
-	}
-
-	virtual ~AdsException() throw()
-	{
-	}
-
-	virtual const char *what() const throw()
-	{
-		return m_Message.c_str();
 	}
 
 	const long errorCode;
-
-    protected:
-	const std::string m_Message;
 };

--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -109,7 +109,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif ()
 
 if (BUILD_SHARED_LIBS)
-    target_compile_definitions(TcAdsLib
+    target_compile_definitions(AdsLib
             PUBLIC
             BHF_ADS_EXPORT_C
             BHF_ADS_USE_TWINCAT_ORDER

--- a/AdsLib/MasterDcStatAccess.cpp
+++ b/AdsLib/MasterDcStatAccess.cpp
@@ -69,7 +69,7 @@ long MasterDcStatAccess::Print(std::ostream &os) const
 			 sizeof(stat.posArr) / sizeof(stat.posArr[0])>
 		rowNames{ {
 			"1", "2", "5", "10", "20", "50", "100", "200", "500",
-			"\u221E" // infinity symbol
+			u8"\u221E" // infinity symbol
 		} };
 
 	os << "Deviation <" << " | " << "Count (neg)" << " | " << "Count (pos)"

--- a/AdsLib/standalone/AmsRouter.cpp
+++ b/AdsLib/standalone/AmsRouter.cpp
@@ -80,7 +80,7 @@ long AmsRouter::AddRoute(AmsNetId ams, const std::string &host)
 		}
 
 		return -1;
-	} catch (std::exception &e) {
+	} catch (...) {
 		lock.lock();
 		connection_attempts.erase(ams);
 		connection_attempt_events.notify_all();

--- a/AdsLibTestRef/CMakeLists.txt
+++ b/AdsLibTestRef/CMakeLists.txt
@@ -2,6 +2,10 @@
 if (NOT TcAdsDll_FOUND)
     return()
 endif ()
+# Skip this test if we are not on Windows or FreeBSD system
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    return()
+endif ()
 
 set(SOURCES
         main.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,14 +36,14 @@ include(GNUInstallDirs)
 
 option(WITH_EXAMPLES "Build the examples (for the variant)" ON)
 option(WITH_TESTS "Build the test (for the variant)" ON)
-option(STANDALONE_ONLY "Build only the AdsLib as stand alone (no TwinCat TcAdsDll targets)" OFF)
+option(STANDALONE_ONLY "Build only the AdsLib as stand alone (no TwinCAT TcAdsDll targets)" OFF)
 
 #Find the needed dependencies
 find_package(Threads REQUIRED)
 if (NOT STANDALONE_ONLY)
     find_package(TcAdsDll)
     if (NOT TcAdsDll_FOUND)
-        message(WARNING "Could NOT find TcAdsDll. TwinCat project targets will not be added.")
+        message(WARNING "Could NOT find TcAdsDll. TwinCAT router project targets will not be added.")
     endif ()
 endif ()
 # This list variable will contain all the targets that are created and need to be install.

--- a/cmake/FindTcAdsDll.cmake
+++ b/cmake/FindTcAdsDll.cmake
@@ -16,15 +16,10 @@ if (NOT TcAdsDll_FIND_QUIETLY)
     message(STATUS "Looking for TcAdsDll (TwinCAT ADS-DLL)...")
 endif ()
 
-if (NOT WIN32)
-    message(WARNING "FindTcAdsDll.cmake only tested on WINDOWS")
-endif ()
-
 if (WIN32)
     # Typical install locations on Windows
     set(_TcAdsDll_PATH "$ENV{SystemDrive}/TwinCAT/AdsApi/TcAdsDll")
 else ()
-    # TODO: Linux not tested. Set additional known default locations to search.
     set(_TcAdsDll_PATH)
 endif ()
 # Find the include headers
@@ -34,7 +29,7 @@ find_path(TcAdsDll_INCLUDE_DIR
         PATH_SUFFIXES "Include" "include"
 )
 # Find all related files base on the include files location. This is done
-# assuming that the files are ordered as install by TwinCat. If they are
+# assuming that the files are ordered as install by TwinCAT. If they are
 # in some other configuration this will not work.
 if (WIN32)
     cmake_path(GET TcAdsDll_INCLUDE_DIR PARENT_PATH TcAdsDll_ROOT_DIR)
@@ -62,7 +57,6 @@ if (WIN32)
             NO_DEFAULT_PATH
     )
 else ()
-    # TODO: Linux not tested. We just try to look for the library by name.
     find_library(TcAdsDll_LIBRARY
             NAMES TcAdsDll
     )


### PR DESCRIPTION
This pull request fixes small issues with cmake and warnings inside the AdsLib.  The commits can be squash into a single commit but are currently separated for easier review. See commit messages for a more in-depth explanation of some of the fixes. 

 - Remove  extra warnings on FindTcAdsDll.cmake
 - Fix typo on 'TwinCAT' naming use on cmake.
 - Fix exception handling on AmsRouter.cpp
 - Use prefix u8 for utf-8 string literal.
 -  Fix clang-tidy ERR60-CPP rule on AdsException.h